### PR TITLE
Add a simple collector to generate flame graph data

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/core/collector/FlamegraphCollector.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/collector/FlamegraphCollector.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2015 Richard Warburton (richard.warburton@gmail.com)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ **/
+package com.insightfullogic.honest_profiler.core.collector;
+
+import com.insightfullogic.honest_profiler.core.Monitor;
+import com.insightfullogic.honest_profiler.core.parser.LogEventListener;
+import com.insightfullogic.honest_profiler.core.parser.Method;
+import com.insightfullogic.honest_profiler.core.parser.StackFrame;
+import com.insightfullogic.honest_profiler.core.parser.TraceStart;
+import com.insightfullogic.honest_profiler.core.sources.LogSource;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FlamegraphCollector implements LogEventListener {
+    private Map<Long, Method> methods = new HashMap<Long, Method>();
+    private Map<List<Long>, Long> flameGraph = new HashMap<List<Long>, Long>();
+    private List<Long> currentTrace;
+    private static Method unknownMethod = new Method(-1, "<unknown>", "unknown.Unknown", "unknown");
+
+    @Override
+    public void handle(TraceStart traceStart) {
+        addCurrentTrace();
+        currentTrace = new ArrayList<Long>();
+    }
+
+    @Override
+    public void handle(StackFrame stackFrame) {
+        currentTrace.add(stackFrame.getMethodId());
+    }
+
+    @Override
+    public void handle(Method newMethod) {
+        methods.put(newMethod.getMethodId(), newMethod);
+    }
+
+    @Override
+    public void endOfLog() {
+        addCurrentTrace();
+    }
+
+    public FlamegraphData toData() throws Exception {
+        Map<List<Method>, Long> converted = new HashMap<List<Method>, Long>(flameGraph.size());
+
+        for (Map.Entry<List<Long>, Long> entry : flameGraph.entrySet()) {
+            List<Long> methodIds = entry.getKey();
+            List<Method> trace = new ArrayList<Method>(methodIds.size());
+
+            for (Long methodId : methodIds) {
+                Method method = methods.get(methodId);
+
+                if (method == null)
+                    method = unknownMethod;
+
+                trace.add(method);
+            }
+
+            converted.put(trace, entry.getValue());
+        }
+
+        return new FlamegraphData(converted);
+    }
+
+    public static FlamegraphData readFlamegraph(LogSource source) throws Exception {
+        FlamegraphCollector collector = new FlamegraphCollector();
+
+        Monitor.consumeFile(source, collector);
+
+        return collector.toData();
+    }
+
+    private void addCurrentTrace() {
+        if (currentTrace == null || currentTrace.size() == 0)
+            return;
+        Long entry = flameGraph.get(currentTrace);
+
+        flameGraph.put(currentTrace, entry == null ? 1 : entry + 1);
+    }
+}

--- a/src/main/java/com/insightfullogic/honest_profiler/core/collector/FlamegraphData.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/collector/FlamegraphData.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015 Richard Warburton (richard.warburton@gmail.com)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ **/
+package com.insightfullogic.honest_profiler.core.collector;
+
+import com.insightfullogic.honest_profiler.core.parser.Method;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FlamegraphData {
+    private Map<List<Method>, Long> flameGraph;
+
+    public FlamegraphData(Map<List<Method>, Long> flameGraph) {
+        this.flameGraph = flameGraph;
+    }
+
+    public Map<List<Method>, Long> getFlameGraph() {
+        return flameGraph;
+    }
+
+    public void writeTo(Writer out) throws IOException {
+        for (Map.Entry<List<Method>, Long> item : flameGraph.entrySet()) {
+            writeTrace(out, item.getKey(), item.getValue());
+        }
+    }
+
+    private void writeTrace(Writer out, List<Method> trace, long weight) throws IOException {
+        if (trace.size() == 0)
+            return;
+        boolean isFirstFrame = true;
+
+        for (int i = trace.size() - 1; i >= 0; --i) {
+            Method method = trace.get(i);
+
+            if (!isFirstFrame)
+                out.write(";");
+            isFirstFrame = false;
+
+            out.write(method.getClassName());
+            out.write(".");
+            out.write(method.getMethodName());
+        }
+
+        out.write(" ");
+        out.write(Long.toString(weight));
+        out.write("\n");
+    }
+}

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/Flamegraph.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/Flamegraph.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015 Richard Warburton (richard.warburton@gmail.com)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ **/
+package com.insightfullogic.honest_profiler.ports;
+
+import com.insightfullogic.honest_profiler.core.collector.FlamegraphCollector;
+import com.insightfullogic.honest_profiler.core.collector.FlamegraphData;
+import com.insightfullogic.honest_profiler.core.sources.LogSource;
+import com.insightfullogic.honest_profiler.ports.sources.FileLogSource;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+public class Flamegraph {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.out.print(
+                "Usage: java com.insightfullogic.honest_profiler.ports.Flamegraph <profile.hpl> <profile.txt>\n" +
+                "\n" +
+                "The output needs to be processed with the tools at https://github.com/brendangregg/FlameGraph to produce the actual flamegraph\n");
+            System.exit(1);
+        }
+
+        String in = args[0], out = args[1];
+        LogSource source = new FileLogSource(new File(in));
+
+        try (Writer output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(out)))) {
+            FlamegraphData  data = FlamegraphCollector.readFlamegraph(source);
+
+            data.writeTo(output);
+        }
+    }
+}


### PR DESCRIPTION
The pull request adds a generic class to aggregate the data (under core.collector) and trivial wrapper that can be used from the command line (under ports, I'm not sure it's the best place).