### PR TITLE
Some changes to the way sampling intervals are specified/used

### DIFF
--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -152,8 +152,12 @@ static void parseArguments(char *options, ConfigurationOptions &configuration) {
             continue;
         } else {
             value++;
-            if (strstr(key, "interval") == key) {
-                configuration.samplingInterval = atoi(value);
+            if (strstr(key, "intervalMin") == key) {
+                configuration.samplingIntervalMin = atoi(value);
+            } else if (strstr(key, "intervalMax") == key) {
+                configuration.samplingIntervalMax = atoi(value);
+            } else if (strstr(key, "interval") == key) {
+                configuration.samplingIntervalMin = configuration.samplingIntervalMax = atoi(value);
             } else if (strstr(key, "logPath") == key) {
                 size_t  size = (next == 0) ? strlen(key) : (size_t) (next - value);
                 configuration.logFilePath = (char*) malloc(size * sizeof(char));

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -14,11 +14,12 @@ const int DEFAULT_SAMPLING_INTERVAL = 1;
 
 struct ConfigurationOptions {
     /** Interval in microseconds */
-    int samplingInterval;
+    int samplingIntervalMin, samplingIntervalMax;
     char* logFilePath;
 
     void initializeDefaults() {
-        samplingInterval = DEFAULT_SAMPLING_INTERVAL;
+        samplingIntervalMin = DEFAULT_SAMPLING_INTERVAL;
+        samplingIntervalMax = DEFAULT_SAMPLING_INTERVAL;
         logFilePath = NULL;
     }
 };

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -54,7 +54,7 @@ void Processor::run() {
             return;
         }
 
-        if (!isRunning.load()) {
+        if (!isRunning_.load()) {
             return;
         }
 
@@ -77,6 +77,10 @@ void Processor::start(JNIEnv *jniEnv) {
 }
 
 void Processor::stop() {
-    isRunning.store(false);
+    isRunning_.store(false);
     std::cout << "Stop\n";
+}
+
+bool Processor::isRunning() const {
+    return isRunning_.load();
 }

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -47,20 +47,28 @@ void sleep_for_millis(uint period) {
 }
 
 void Processor::run() {
-    while (true) {
-        while (buffer_.pop());
+    int popped = 0;
 
-        if (!handler_.updateSigprofInterval()) {
-            return;
+    while (true) {
+        while (buffer_.pop()) {
+            ++popped;
+        }
+
+        if (popped > 200) {
+            if (!handler_.updateSigprofInterval()) {
+                break;
+            }
+            popped = 0;
         }
 
         if (!isRunning_.load()) {
-            return;
+            break;
         }
 
-        // TODO: make this configurable
-        sleep_for_millis(1);
+        sleep_for_millis(interval_);
     }
+
+    handler_.stopSigprof();
 }
 
 void Processor::start(JNIEnv *jniEnv) {

--- a/src/main/cpp/processor.h
+++ b/src/main/cpp/processor.h
@@ -9,8 +9,8 @@ class Processor {
 
 public:
     explicit Processor(jvmtiEnv* jvmti, LogWriter& logWriter,
-            CircularQueue& buffer, SignalHandler& handler)
-            : jvmti_(jvmti), logWriter_(logWriter), buffer_(buffer), isRunning_(true), handler_(handler) {
+            CircularQueue& buffer, SignalHandler& handler, int interval)
+            : jvmti_(jvmti), logWriter_(logWriter), buffer_(buffer), isRunning_(true), handler_(handler), interval_(interval) {
     }
 
     void start(JNIEnv *jniEnv);
@@ -31,6 +31,8 @@ private:
     std::atomic_bool isRunning_;
 
     SignalHandler& handler_;
+
+    int interval_;
 
     void startCallback(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg);
 

--- a/src/main/cpp/processor.h
+++ b/src/main/cpp/processor.h
@@ -10,7 +10,7 @@ class Processor {
 public:
     explicit Processor(jvmtiEnv* jvmti, LogWriter& logWriter,
             CircularQueue& buffer, SignalHandler& handler)
-            : jvmti_(jvmti), logWriter_(logWriter), buffer_(buffer), isRunning(true), handler_(handler) {
+            : jvmti_(jvmti), logWriter_(logWriter), buffer_(buffer), isRunning_(true), handler_(handler) {
     }
 
     void start(JNIEnv *jniEnv);
@@ -19,6 +19,8 @@ public:
 
     void stop();
 
+    bool isRunning() const;
+
 private:
     jvmtiEnv* jvmti_;
 
@@ -26,7 +28,7 @@ private:
 
     CircularQueue& buffer_;
 
-    std::atomic_bool isRunning;
+    std::atomic_bool isRunning_;
 
     SignalHandler& handler_;
 

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -98,11 +98,11 @@ bool Profiler::start(JNIEnv *jniEnv) {
     // instance of Profiler
     handler_.SetAction(&bootstrapHandle);
     processor->start(jniEnv);
-    return handler_.updateSigprofInterval(1);
+    return handler_.updateSigprofInterval();
 }
 
 void Profiler::stop() {
-    handler_.updateSigprofInterval(0);
+    handler_.stopSigprof();
     processor->stop();
     signal(SIGPROF, SIG_IGN);
 }

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -107,3 +107,6 @@ void Profiler::stop() {
     signal(SIGPROF, SIG_IGN);
 }
 
+bool Profiler::isRunning() const {
+    return processor->isRunning();
+}

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -49,6 +49,8 @@ public:
 
     void handle(int signum, siginfo_t *info, void *context);
 
+    bool isRunning() const;
+
     ~Profiler() {
         delete buffer;
         delete logFile;

--- a/src/main/cpp/signal_handler.cpp
+++ b/src/main/cpp/signal_handler.cpp
@@ -28,6 +28,8 @@ bool SignalHandler::updateSigprofInterval() {
 }
 
 bool SignalHandler::updateSigprofInterval(const int timingInterval) {
+    if (timingInterval == currentInterval)
+        return true;
     static struct itimerval timer;
     timer.it_interval.tv_sec = 0;
     timer.it_interval.tv_usec = timingInterval;
@@ -36,6 +38,7 @@ bool SignalHandler::updateSigprofInterval(const int timingInterval) {
         logError("Scheduling profiler interval failed with error %d\n", errno);
         return false;
     }
+    currentInterval = timingInterval;
     return true;
 }
 

--- a/src/main/cpp/signal_handler.cpp
+++ b/src/main/cpp/signal_handler.cpp
@@ -21,10 +21,9 @@ namespace {
 } // namespace
 
 bool SignalHandler::updateSigprofInterval() {
-    //bool res = updateSigprofInterval(timingIntervals[intervalIndex]);
-    //intervalIndex = (intervalIndex + 1) % NUMBER_OF_INTERVALS;
-    //return res;
-    return updateSigprofInterval(1);
+    bool res = updateSigprofInterval(timingIntervals[intervalIndex]);
+    intervalIndex = (intervalIndex + 1) % NUMBER_OF_INTERVALS;
+    return res;
 }
 
 bool SignalHandler::updateSigprofInterval(const int timingInterval) {

--- a/src/main/cpp/signal_handler.h
+++ b/src/main/cpp/signal_handler.h
@@ -22,6 +22,7 @@ public:
         for (int i = 0; i < NUMBER_OF_INTERVALS; i++) {
             timingIntervals[i] = rand() % (samplingInterval * 2) + 1;
         }
+        currentInterval = -1;
     }
 
     struct sigaction SetAction(void (*sigaction)(int, siginfo_t *, void *));
@@ -32,8 +33,8 @@ public:
 
 private:
     int intervalIndex;
-
     int *timingIntervals;
+    int currentInterval;
 
     DISALLOW_COPY_AND_ASSIGN(SignalHandler);
 };

--- a/src/main/cpp/signal_handler.h
+++ b/src/main/cpp/signal_handler.h
@@ -15,12 +15,13 @@ const int NUMBER_OF_INTERVALS = 1024;
 
 class SignalHandler {
 public:
-    SignalHandler(const int samplingInterval) {
+    SignalHandler(const int samplingIntervalMin, const int samplingIntervalMax) {
         intervalIndex = 0;
         timingIntervals = new int[NUMBER_OF_INTERVALS];
         srand (time(NULL));
+        int range = samplingIntervalMax - samplingIntervalMin + 1;
         for (int i = 0; i < NUMBER_OF_INTERVALS; i++) {
-            timingIntervals[i] = rand() % (samplingInterval * 2) + 1;
+            timingIntervals[i] = samplingIntervalMin + rand() % range;
         }
         currentInterval = -1;
     }
@@ -30,6 +31,8 @@ public:
     bool updateSigprofInterval();
 
     bool updateSigprofInterval(int);
+
+    bool stopSigprof() { return updateSigprofInterval(0); }
 
 private:
     int intervalIndex;

--- a/src/test/cpp/test_agent.cpp
+++ b/src/test/cpp/test_agent.cpp
@@ -9,14 +9,20 @@
 TEST(ParseSetsDefaultOptions) {
     ConfigurationOptions options;
     parseArguments((char*) NULL, options);
-    CHECK_EQUAL(options.samplingInterval, DEFAULT_SAMPLING_INTERVAL);
+    CHECK_EQUAL(options.samplingIntervalMin, DEFAULT_SAMPLING_INTERVAL);
+    CHECK_EQUAL(options.samplingIntervalMax, DEFAULT_SAMPLING_INTERVAL);
     CHECK(!options.logFilePath);
 }
 
 TEST(ParsesSamplingInterval) {
     ConfigurationOptions options;
     parseArguments((char *) "interval=10", options);
-    CHECK_EQUAL(10, options.samplingInterval);
+    CHECK_EQUAL(10, options.samplingIntervalMin);
+    CHECK_EQUAL(10, options.samplingIntervalMax);
+
+    parseArguments((char *) "intervalMin=12,intervalMax=17", options);
+    CHECK_EQUAL(12, options.samplingIntervalMin);
+    CHECK_EQUAL(17, options.samplingIntervalMax);
 }
 
 TEST(ParsesLogPath) {
@@ -31,11 +37,13 @@ TEST(ParsesMultipleArguments) {
     ConfigurationOptions options;
     char* string = (char *) "interval=10,logPath=/home/richard/log.hpl";
     parseArguments(string, options);
-    CHECK_EQUAL(10, options.samplingInterval);
+    CHECK_EQUAL(10, options.samplingIntervalMin);
+    CHECK_EQUAL(10, options.samplingIntervalMax);
     CHECK_EQUAL("/home/richard/log.hpl", options.logFilePath);
 
     string = (char *) "logPath=/home/richard/log.hpl,interval=10";
     parseArguments(string, options);
-    CHECK_EQUAL(10, options.samplingInterval);
+    CHECK_EQUAL(10, options.samplingIntervalMin);
+    CHECK_EQUAL(10, options.samplingIntervalMax);
     CHECK_EQUAL("/home/richard/log.hpl", options.logFilePath);
 }


### PR DESCRIPTION
In the current code base, there is code to randomize the sampling interval, but it got disabled by 18dbd6c45ffc9d60490fab6b6d4e727af805cfc2.

This PR adds back the functionality, but, by default, uses a fixed sampling interval, with the option of specifying the interval explicitly via a min/max parameter pair.

Also, when the interval is randomized, it changes it every 200 collected samples rather than on every iteration of the processor loop (resetting the timer too often means the actual intervals are never honored, because the timer is reset on the setitimer() call, which is not syncronized with timer expiration).