### PR TITLE
Various thread-related improvements

### DIFF
--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -71,6 +71,13 @@ void Processor::run() {
 void callbackToRunProcessor(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg) {
     IMPLICITLY_USE(jvmti_env);
     IMPLICITLY_USE(jni_env);
+    //Avoid having the processor thread also receive the PROF signals
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGPROF);
+    if (pthread_sigmask(SIG_BLOCK, &mask, NULL) < 0) {
+        logError("Error setting processor thread signal mask\n");
+    }
     Processor *processor = (Processor *) arg;
     processor->run();
 }

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -76,6 +76,8 @@ private:
 
     SignalHandler handler_;
 
+    static std::atomic<int> handling_signal;
+
     static bool lookupFrameInformation(const JVMPI_CallFrame &frame,
             jvmtiEnv *jvmti,
             MethodListener &logWriter);

--- a/src/main/cpp/signal_handler.cpp
+++ b/src/main/cpp/signal_handler.cpp
@@ -30,8 +30,8 @@ bool SignalHandler::updateSigprofInterval(const int timingInterval) {
     if (timingInterval == currentInterval)
         return true;
     static struct itimerval timer;
-    timer.it_interval.tv_sec = 0;
-    timer.it_interval.tv_usec = timingInterval;
+    timer.it_interval.tv_sec = timingInterval / 1000000;
+    timer.it_interval.tv_usec = timingInterval % 1000000;
     timer.it_value = timer.it_interval;
     if (setitimer(ITIMER_PROF, &timer, 0) == -1) {
         logError("Scheduling profiler interval failed with error %d\n", errno);


### PR DESCRIPTION
This is a set of changes I made while trying to understand why using short sampling intervals leads to either a deadlock or extremely low performance (in one instance a sampling interval of 15ms is fine, with the program completing in a few seconds, but with 5ms the program does not complete in a useful time frame). Haven't got to the bottom of it yet, but for what it's worth according to GDB backtraces it may be that the profiler does force the JVM to stop at a safepoint when inspecting methods and determining line numbers (haven't checked the detail of the corresponding JVM code). Perhaps sampling events in short succession just effectively stop progression of the Java program being executed by the JVM.