### PR TITLE
    When running under Mac OS X or FreeBSD, temporarily block PROF si…

### DIFF
--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -201,6 +201,10 @@ void JNICALL OnThreadStart(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread)
     pthread_sigmask(SIG_UNBLOCK, &prof_signal_mask, NULL);
 }
 
+void JNICALL OnThreadEnd(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread) {
+    pthread_sigmask(SIG_BLOCK, &prof_signal_mask, NULL);
+}
+
 static bool RegisterJvmti(jvmtiEnv *jvmti) {
     sigemptyset(&prof_signal_mask);
     sigaddset(&prof_signal_mask, SIGPROF);
@@ -218,6 +222,7 @@ static bool RegisterJvmti(jvmtiEnv *jvmti) {
 
     callbacks->NativeMethodBind = &OnNativeMethodBind;
     callbacks->ThreadStart = &OnThreadStart;
+    callbacks->ThreadEnd = &OnThreadEnd;
 
     JVMTI_ERROR_RET(
             (jvmti->SetEventCallbacks(callbacks, sizeof(jvmtiEventCallbacks))),
@@ -227,6 +232,7 @@ static bool RegisterJvmti(jvmtiEnv *jvmti) {
             JVMTI_EVENT_VM_DEATH, JVMTI_EVENT_VM_INIT, JVMTI_EVENT_COMPILED_METHOD_LOAD
 #ifdef GETENV_NEW_THREAD_ASYNC_UNSAFE
         ,JVMTI_EVENT_THREAD_START,
+        JVMTI_EVENT_THREAD_END,
         JVMTI_EVENT_NATIVE_METHOD_BIND
 #endif
     };

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -62,12 +62,11 @@ void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jniEnv, jthread thread) {
         CreateJMethodIDsForClass(jvmti, klass);
     }
 
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
     if (CONFIGURATION->host != NULL && CONFIGURATION->port != NULL) {
         controller->start();
     }
-
-    if (CONFIGURATION->start)
-        prof->start(jniEnv);
+#endif
 }
 
 void JNICALL OnClassPrepare(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
@@ -101,6 +100,9 @@ static bool PrepareJvmti(jvmtiEnv *jvmti) {
     caps.can_get_bytecodes = 1;
     caps.can_get_constant_pool = 1;
     caps.can_generate_compiled_method_load_events = 1;
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    caps.can_generate_native_method_bind_events = 1;
+#endif
 
     jvmtiCapabilities all_caps;
     int error;
@@ -128,7 +130,77 @@ static bool PrepareJvmti(jvmtiEnv *jvmti) {
     return true;
 }
 
+sigset_t prof_signal_mask;
+
+void (*actual_JVM_StartThread)(JNIEnv *, jthread) = NULL;
+
+void JVM_StartThread_Interposer(JNIEnv *jni_env, jobject jthread) {
+    pthread_sigmask(SIG_BLOCK, &prof_signal_mask, NULL);
+    actual_JVM_StartThread(jni_env, jthread);
+    pthread_sigmask(SIG_UNBLOCK, &prof_signal_mask, NULL);
+}
+
+//Set up interposition of calls to Thread::run0
+void JNICALL
+OnNativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread,
+                 jmethodID method, void *address, void **new_address_ptr) {
+    if (actual_JVM_StartThread != NULL) {
+        return;
+    }
+
+    char *name_ptr, *signature_ptr;
+
+    int err = jvmti_env->GetMethodName(method, &name_ptr, &signature_ptr, NULL);
+    if (err != JNI_OK) {
+        logError("Error %i retrieving method name", err);
+        return;
+    }
+    if (strcmp(name_ptr, "start0") == 0 && strcmp(signature_ptr, "()V") == 0) {
+        jclass declaringClass;
+        int err = jvmti_env->GetMethodDeclaringClass(method, &declaringClass);
+        if (err != JNI_OK) {
+            logError("Error %i retrieving class", err);
+            goto end;
+        }
+        jclass clazz = jni_env->GetObjectClass(declaringClass);
+        jmethodID getSimpleNameMethod = jni_env->GetMethodID(clazz,
+            "getSimpleName", "()Ljava/lang/String;");
+        jstring jClassName = (jstring) jni_env->CallObjectMethod(declaringClass,
+            getSimpleNameMethod);
+
+        const char *className = jni_env->GetStringUTFChars(jClassName, 0);
+        if (strcmp(className, "Thread") == 0) {
+            *new_address_ptr = (void*) &JVM_StartThread_Interposer;
+            actual_JVM_StartThread = (void (*)(JNIEnv *, jthread)) address;
+        }
+        jni_env->ReleaseStringUTFChars(jClassName, className);
+    }
+end:
+    jvmti_env->Deallocate((unsigned char *) name_ptr);
+    jvmti_env->Deallocate((unsigned char *) signature_ptr);
+}
+
+volatile bool main_started = false;
+
+void JNICALL
+OnThreadStart(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread) {
+    if (!main_started) {
+        jvmtiThreadInfo thread_info;
+        int error = jvmti_env->GetThreadInfo(thread, &thread_info);
+        if (error == JNI_OK) {
+            if (strcmp(thread_info.name, "main") == 0) {
+                main_started = true;
+                if (CONFIGURATION->start)
+                    prof->start(jni_env);
+            }
+        }
+    }
+    pthread_sigmask(SIG_UNBLOCK, &prof_signal_mask, NULL);
+}
+
 static bool RegisterJvmti(jvmtiEnv *jvmti) {
+    sigemptyset(&prof_signal_mask);
+    sigaddset(&prof_signal_mask, SIGPROF);
     // Create the list of callbacks to be called on given events.
     jvmtiEventCallbacks *callbacks = new jvmtiEventCallbacks();
     memset(callbacks, 0, sizeof(jvmtiEventCallbacks));
@@ -141,12 +213,20 @@ static bool RegisterJvmti(jvmtiEnv *jvmti) {
 
     callbacks->CompiledMethodLoad = &CompiledMethodLoad;
 
+    callbacks->NativeMethodBind = &OnNativeMethodBind;
+    callbacks->ThreadStart = &OnThreadStart;
+
     JVMTI_ERROR_RET(
             (jvmti->SetEventCallbacks(callbacks, sizeof(jvmtiEventCallbacks))),
             false);
 
     jvmtiEvent events[] = {JVMTI_EVENT_CLASS_LOAD, JVMTI_EVENT_CLASS_PREPARE,
-            JVMTI_EVENT_VM_DEATH, JVMTI_EVENT_VM_INIT, JVMTI_EVENT_COMPILED_METHOD_LOAD};
+            JVMTI_EVENT_VM_DEATH, JVMTI_EVENT_VM_INIT, JVMTI_EVENT_COMPILED_METHOD_LOAD
+#if defined(__APPLE__) || defined(__FreeBSD__)
+        ,JVMTI_EVENT_THREAD_START,
+        JVMTI_EVENT_NATIVE_METHOD_BIND
+#endif
+    };
 
     size_t num_events = sizeof(events) / sizeof(jvmtiEvent);
 


### PR DESCRIPTION
…gnal while a new thread is being spawned. This prevents the signal handler from being called before the new thread is fully initialized, and thus avoids crashes in GetEnv. The way this is implemented is by interposing calls to the native method Thread::start0. The PROF signal is unblocked in newly-created threads by the OnThreadStart callback.

I also found it necessary to only start profiling once the main thread has been created (as noted in the Java source for the Thread class, start and therefore start0 are not called for the main method thread).

This commit should not introduce any functional changes for platforms other than OS X and FreeBSD.