### PR TITLE
Do not prezero structure used by AsyncGetCallTrace to store its resul…

### DIFF
--- a/src/main/cpp/circular_queue.cpp
+++ b/src/main/cpp/circular_queue.cpp
@@ -2,14 +2,6 @@
 #include <iostream>
 #include <unistd.h>
 
-void safe_reset(void *start, size_t size) {
-    char *base = reinterpret_cast<char *>(start);
-    char *end = base + size;
-    for (char *p = base; p < end; p++) {
-        *p = 0;
-    }
-}
-
 bool CircularQueue::push(const JVMPI_CallTrace &item) {
     size_t currentInput;
     size_t nextInput;

--- a/src/main/cpp/circular_queue.h
+++ b/src/main/cpp/circular_queue.h
@@ -25,12 +25,6 @@ const size_t Size = 1024;
 // effective the gap acts as a sentinel
 const size_t Capacity = Size + 1;
 
-// We have to set every byte to 0 instead of just initializing the
-// individual fields, because the structs might be padded, and we
-// use memcmp on it later.  We can't use memset, because it isn't
-// async-safe.
-void safe_reset(void *start, size_t size);
-
 class QueueListener {
 public:
     virtual void record(const JVMPI_CallTrace &item) = 0;

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -65,9 +65,8 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
     IMPLICITLY_USE(signum);
     IMPLICITLY_USE(info);
 
-    // prepare sample data structure
+    // sample data structure
     JVMPI_CallFrame frames[kMaxFramesToCapture];
-    safe_reset(frames, sizeof(JVMPI_CallFrame) * kMaxFramesToCapture);
 
     JVMPI_CallTrace trace;
     trace.frames = frames;


### PR DESCRIPTION
…ts. This avoids async safety problems with compiler optimizations inserting calls to bzero or memset, which are not async-safe. This does not affect zeroing of padding in the data written out by the profiler.