### PR TITLE
Add a new header for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,8 @@ set(TEST_FILES
     ${SRC_TEST}/test_circular_queue.cpp
     ${SRC_TEST}/test.cpp
     ${SRC_TEST}/test_log_writer.cpp
-    ${SRC_TEST}/test_agent.cpp)
+    ${SRC_TEST}/test_agent.cpp
+    ${SRC_TEST}/test.h)
 
 
 ##########################################################

--- a/src/test/cpp/fixtures.h
+++ b/src/test/cpp/fixtures.h
@@ -1,3 +1,4 @@
+#include "test.h"
 #include "../../main/cpp/circular_queue.h"
 
 #ifndef FIXTURES_H

--- a/src/test/cpp/test.cpp
+++ b/src/test/cpp/test.cpp
@@ -1,7 +1,3 @@
-#ifdef __APPLE__
-#include <UnitTest++/UnitTest++/UnitTest++.h>
-#else
-#include <UnitTest++.h>
-#endif
+#include "test.h"
 
 int main() { return UnitTest::RunAllTests(); }

--- a/src/test/cpp/test.h
+++ b/src/test/cpp/test.h
@@ -1,0 +1,10 @@
+#ifndef HONEST_PROFILER_TEST_H
+#define HONEST_PROFILER_TEST_H
+
+#ifdef __APPLE__
+#include <UnitTest++/UnitTest++/UnitTest++.h>
+#else
+#include <UnitTest++.h>
+#endif
+
+#endif //HONEST_PROFILER_TEST_H

--- a/src/test/cpp/test_agent.cpp
+++ b/src/test/cpp/test_agent.cpp
@@ -1,13 +1,8 @@
-#ifdef __APPLE__
-#include <UnitTest++/UnitTest++/UnitTest++.h>
-#else
-#include <UnitTest++.h>
-#endif
-
 #include <thread>
 #include <vector>
 #include <iostream>
 #include "fixtures.h"
+#include "test.h"
 #include "../../main/cpp/agent.cpp"
 
 TEST(ParseSetsDefaultOptions) {

--- a/src/test/cpp/test_circular_queue.cpp
+++ b/src/test/cpp/test_circular_queue.cpp
@@ -1,13 +1,8 @@
-#ifdef __APPLE__
-#include <UnitTest++/UnitTest++/UnitTest++.h>
-#else
-#include <UnitTest++.h>
-#endif
-
 #include <thread>
 #include <vector>
 #include <iostream>
 #include "fixtures.h"
+#include "test.h"
 
 #define givenStackTrace(envId)                                                 \
   JVMPI_CallFrame frame0 = {};                                                 \

--- a/src/test/cpp/test_log_writer.cpp
+++ b/src/test/cpp/test_log_writer.cpp
@@ -1,15 +1,9 @@
-#ifdef __APPLE__
-#include <UnitTest++/UnitTest++/UnitTest++.h>
-#else
-#include <UnitTest++.h>
-#endif
 #include <iostream>
 #include <fstream>
 #include <limits>
-
 #include "fixtures.h"
 #include "ostreambuf.h"
-#include "../../main/cpp/circular_queue.h"
+#include "test.h"
 #include "../../main/cpp/log_writer.h"
 
 using std::ostream;


### PR DESCRIPTION
- Eliminates the repetitive `#ifdef __APPLE__` in test files
- Tested building on Ubuntu 14.04 and Mac OS X 10.11.3