### PR TITLE
Use vprintf for logError

### DIFF
--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -225,7 +225,7 @@ void logError(const char *__restrict format, ...) {
     va_list arg;
 
     va_start(arg, format);
-    fprintf(stderr, format, arg);
+    vfprintf(stderr, format, arg);
     va_end(arg);
 }
 


### PR DESCRIPTION
- Switch to vprintf so varargs passed to logError will be formatted properly