### PR TITLE
Ensure strings are NUL terminated

### DIFF
--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -142,8 +142,17 @@ static bool RegisterJvmti(jvmtiEnv *jvmti) {
     return true;
 }
 
+static char *safe_copy_string(const char *value, const char *next) {
+    size_t size = (next == 0) ? strlen(value) : (size_t) (next - value);
+    char *dest = (char *) malloc((size + 1) * sizeof(char));
+
+    strncpy(dest, value, size);
+    dest[size] = '\0';
+
+    return dest;
+}
+
 static void parseArguments(char *options, ConfigurationOptions &configuration) {
-    configuration.initializeDefaults();
     char* next = options;
     for (char *key = options; next != NULL; key = next + 1) {
         char *value = strchr(key, '=');
@@ -160,9 +169,7 @@ static void parseArguments(char *options, ConfigurationOptions &configuration) {
             } else if (strstr(key, "interval") == key) {
                 configuration.samplingIntervalMin = configuration.samplingIntervalMax = atoi(value);
             } else if (strstr(key, "logPath") == key) {
-                size_t  size = (next == 0) ? strlen(key) : (size_t) (next - value);
-                configuration.logFilePath = (char*) malloc(size * sizeof(char));
-                strncpy(configuration.logFilePath, value, size);
+                configuration.logFilePath = safe_copy_string(value, next);
             } else if (strstr(key, "start") == key) {
                 configuration.start = atoi(value);
             } else {

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -21,11 +21,11 @@ struct ConfigurationOptions {
     char* logFilePath;
     bool start;
 
-    void initializeDefaults() {
-        samplingIntervalMin = DEFAULT_SAMPLING_INTERVAL;
-        samplingIntervalMax = DEFAULT_SAMPLING_INTERVAL;
-        logFilePath = NULL;
-        start = true;
+    ConfigurationOptions() :
+            samplingIntervalMin(DEFAULT_SAMPLING_INTERVAL),
+            samplingIntervalMax(DEFAULT_SAMPLING_INTERVAL),
+            logFilePath(NULL),
+            start(true) {
     }
 };
 

--- a/src/test/cpp/test_agent.cpp
+++ b/src/test/cpp/test_agent.cpp
@@ -51,3 +51,22 @@ TEST(ParsesMultipleArguments) {
     CHECK_EQUAL(10, options.samplingIntervalMax);
     CHECK_EQUAL("/home/richard/log.hpl", options.logFilePath);
 }
+
+TEST(SafelyTerminatesStrings) {
+    char* string = (char *) "/home/richard/log.hpl";
+    char* result = safe_copy_string(string, NULL);
+
+    CHECK_EQUAL(std::string("/home/richard/log.hpl"), result);
+    CHECK_EQUAL('\0', result[21]);
+
+    free(result);
+
+    string = (char *) "/home/richard/log.hpl,interval=10";
+    char* next = string + 21;
+    result = safe_copy_string(string, next);
+
+    CHECK_EQUAL(std::string("/home/richard/log.hpl"), result);
+    CHECK_EQUAL('\0', result[21]);
+
+    free(result);
+}


### PR DESCRIPTION
- Switch ConfigurationOptions to use an initializer list instead of the initializeDefaults method
- Safely copy strings, ensuring that they are always NUL-terminated
- If nothing else, there's a bug in the original size calculation where it does `strlen(key)` instead of `strlen(value)`