### PR TITLE
Logs and errors

### DIFF
--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -32,7 +32,7 @@ void CreateJMethodIDsForClass(jvmtiEnv *jvmti, jclass klass) {
         // be loaded but not prepared at this point.
         JvmtiScopedPtr<char> ksig(jvmti);
         JVMTI_ERROR((jvmti->GetClassSignature(klass, ksig.GetRef(), NULL)));
-        logError("Failed to create method IDs for methods in class %s with error %d ",
+        logError("ERROR: Failed to create method IDs for methods in class %s with error %d\n",
                  ksig.Get(), e);
     }
 }
@@ -104,7 +104,7 @@ static bool PrepareJvmti(jvmtiEnv *jvmti) {
 
         // This adds the capabilities.
         if ((error = jvmti->AddCapabilities(&caps)) != JVMTI_ERROR_NONE) {
-            logError("Failed to add capabilities with error %d\n", error);
+            logError("ERROR: Failed to add capabilities with error %d\n", error);
             return false;
         }
     }
@@ -158,7 +158,7 @@ static void parseArguments(char *options, ConfigurationOptions &configuration) {
         char *value = strchr(key, '=');
         next = strchr(key, ',');
         if (value == NULL) {
-            logError("No value for key %s\n", key);
+            logError("WARN: No value for key %s\n", key);
             continue;
         } else {
             value++;
@@ -173,7 +173,7 @@ static void parseArguments(char *options, ConfigurationOptions &configuration) {
             } else if (strstr(key, "start") == key) {
                 configuration.start = atoi(value);
             } else {
-                logError("Unknown configuration option: %s\n", key);
+                logError("WARN: Unknown configuration option: %s\n", key);
             }
         }
     }
@@ -187,7 +187,7 @@ AGENTEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved
 
     if ((err = (jvm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION))) !=
             JNI_OK) {
-        logError("JVMTI initialisation Error %d\n", err);
+        logError("ERROR: JVMTI initialisation error %d\n", err);
         return 1;
     }
 
@@ -201,12 +201,12 @@ AGENTEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved
       */
 
     if (!PrepareJvmti(jvmti)) {
-        logError("Failed to initialize JVMTI.  Continuing...\n");
+        logError("ERROR: Failed to initialize JVMTI. Continuing...\n");
         return 0;
     }
 
     if (!RegisterJvmti(jvmti)) {
-        logError("Failed to enable JVMTI events.  Continuing...\n");
+        logError("ERROR: Failed to enable JVMTI events. Continuing...\n");
         // We fail hard here because we may have failed in the middle of
         // registering callbacks, which will leave the system in an
         // inconsistent state.

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -17,15 +17,15 @@ static jthread newThread(JNIEnv *jniEnv) {
 
     thrClass = jniEnv->FindClass("java/lang/Thread");
     if (thrClass == NULL) {
-        logError("Cannot find Thread class\n");
+        logError("WARN: Cannot find Thread class\n");
     }
     cid = jniEnv->GetMethodID(thrClass, "<init>", "()V");
     if (cid == NULL) {
-        logError("Cannot find Thread constructor method\n");
+        logError("WARN: Cannot find Thread constructor method\n");
     }
     res = jniEnv->NewObject(thrClass, cid);
     if (res == NULL) {
-        logError("Cannot create new Thread object\n");
+        logError("WARN: Cannot create new Thread object\n");
     } else {
        jmethodID mid = jniEnv->GetMethodID(thrClass, "setName","(Ljava/lang/String;)V");
        jniEnv->CallObjectMethod(res, mid, jniEnv->NewStringUTF("Honest Profiler Daemon Thread"));  

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -22,7 +22,7 @@ bool Profiler::lookupFrameInformation(const JVMPI_CallFrame &frame,
                          "GetMethodName on a jmethodID involved in a stacktrace "
                          "resulted in an INVALID_METHODID error which usually "
                          "indicates its declaring class has been unloaded.\n");
-                logError("Unexpected JVMTI error %d in GetMethodName", error);
+                logError("Unexpected JVMTI error %d in GetMethodName\n", error);
             }
         }
         return false;
@@ -93,6 +93,11 @@ JNIEnv *Profiler::getJNIEnv() {
 }
 
 bool Profiler::start(JNIEnv *jniEnv) {
+    if (isRunning()) {
+        logError("WARN: Start called but sampling is already running\n");
+        return true;
+    }
+
     // reference back to Profiler::handle on the singleton
     // instance of Profiler
     handler_.SetAction(&bootstrapHandle);

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -38,6 +38,11 @@ public:
 
         logFile = new ofstream(fileName, ofstream::out | ofstream::binary);
 
+        if (logFile->fail()) {
+            // The JVM will still continue to run though; could call abort() to terminate the JVM abnormally.
+            logError("ERROR: Failed to open file %s for writing\n", fileName);
+        }
+
         writer = new LogWriter(*logFile, &Profiler::lookupFrameInformation, jvmti);
         buffer = new CircularQueue(*writer);
 


### PR DESCRIPTION
- Log additional error cases
- Also prevent `Profiler::start` from creating multiple threads if called repeatedly
- Log messages with an ERROR or WARN prefix. Makes it slightly easier to determine the severity of the message when looking at a log file for stderr