### PR TITLE
Enable sampling to be controlled via a socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,11 @@ set(SOURCE_FILES
     ${SRC}/agent.cpp
     ${SRC}/circular_queue.cpp
     ${SRC}/circular_queue.h
+    ${SRC}/common.cpp
+    ${SRC}/common.h
     ${SRC}/control.cpp
+    ${SRC}/controller.cpp
+    ${SRC}/controller.h
     ${SRC}/globals.h
     ${SRC}/log_writer.cpp
     ${SRC}/log_writer.h

--- a/src/main/cpp/common.cpp
+++ b/src/main/cpp/common.cpp
@@ -1,0 +1,34 @@
+#include "common.h"
+
+jthread newThread(JNIEnv *jniEnv, const char *threadName) {
+    jclass thrClass;
+    jmethodID cid;
+    jthread res;
+
+    thrClass = jniEnv->FindClass("java/lang/Thread");
+    if (thrClass == NULL) {
+        logError("WARN: Cannot find Thread class\n");
+    }
+    cid = jniEnv->GetMethodID(thrClass, "<init>", "()V");
+    if (cid == NULL) {
+        logError("WARN: Cannot find Thread constructor method\n");
+    }
+    res = jniEnv->NewObject(thrClass, cid);
+    if (res == NULL) {
+        logError("WARN: Cannot create new Thread object\n");
+    } else {
+        jmethodID mid = jniEnv->GetMethodID(thrClass, "setName", "(Ljava/lang/String;)V");
+        jniEnv->CallObjectMethod(res, mid, jniEnv->NewStringUTF(threadName));
+    }
+    return res;
+}
+
+JNIEnv *getJNIEnv(JavaVM *jvm) {
+    JNIEnv *jniEnv = NULL;
+    int getEnvStat = jvm->GetEnv((void **) &jniEnv, JNI_VERSION_1_6);
+    // check for issues
+    if (getEnvStat == JNI_EDETACHED || getEnvStat == JNI_EVERSION) {
+        jniEnv = NULL;
+    }
+    return jniEnv;
+}

--- a/src/main/cpp/common.h
+++ b/src/main/cpp/common.h
@@ -1,0 +1,11 @@
+#ifndef HONEST_PROFILER_COMMON_H
+#define HONEST_PROFILER_COMMON_H
+
+#include <jvmti.h>
+#include "globals.h"
+
+jthread newThread(JNIEnv *jniEnv, const char *threadName);
+
+JNIEnv *getJNIEnv(JavaVM *jvm);
+
+#endif

--- a/src/main/cpp/controller.cpp
+++ b/src/main/cpp/controller.cpp
@@ -1,0 +1,133 @@
+#include "controller.h"
+
+void controllerRunnable(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg) {
+    IMPLICITLY_USE(jvmti_env);
+    IMPLICITLY_USE(jni_env);
+    Controller *control = (Controller *) arg;
+    sigset_t mask;
+
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGPROF);
+
+    if (pthread_sigmask(SIG_BLOCK, &mask, NULL) < 0) {
+        logError("ERROR: unable to set controller thread signal mask\n");
+    }
+
+    control->run();
+}
+
+void Controller::start() {
+    JNIEnv *env = getJNIEnv(jvm_);
+
+    if (env == NULL) {
+        logError("ERROR: Failed to obtain JNIEnv\n");
+        return;
+    }
+
+    jthread thread = newThread(env, "Honest Profiler Controller Thread");
+    jvmtiStartFunction callback = controllerRunnable;
+    jvmti_->RunAgentThread(thread, callback, this, JVMTI_THREAD_NORM_PRIORITY);
+}
+
+void Controller::stop() {
+    isRunning_.store(false);
+}
+
+void Controller::run() {
+    struct addrinfo hints, *res;
+    char buf[MAX_DATA_SIZE];
+    struct sockaddr_storage clientAddress;
+    socklen_t addressSize = sizeof(clientAddress);
+    ssize_t bytesRead;
+    int result, listener, clientConnection;
+    const int yes = 1;
+
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    if ((result = getaddrinfo(configuration_->host, configuration_->port, &hints, &res)) != 0) {
+        logError("ERROR: getaddrinfo: %s\n", gai_strerror(result));
+        return;
+    }
+
+    if ((listener = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
+        logError("ERROR: Failed to open socket: %s\n", strerror(errno));
+        return;
+    }
+
+    setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
+
+    if (bind(listener, res->ai_addr, res->ai_addrlen) == -1) {
+        logError("ERROR: Failed to bind successfully: %s\n", strerror(errno));
+        close(listener);
+        return;
+    }
+
+    if (listen(listener, 3) == -1) {
+        logError("ERROR: Failed to listen: %s\n", strerror(errno));
+        return;
+    }
+
+    while (isRunning_.load()) {
+        if ((clientConnection = accept(listener, (struct sockaddr *) &clientAddress, &addressSize)) == -1) {
+            logError("ERROR: Failed to accept incoming connection: %s\n", strerror(errno));
+            continue;
+        }
+
+        if ((bytesRead = recv(clientConnection, buf, MAX_DATA_SIZE - 1, 0)) == -1) {
+            if (bytesRead == 0) {
+                // client closed the connection
+            } else {
+                logError("ERROR: Failed to read data from client: %s\n", strerror(errno));
+            }
+        } else {
+            buf[bytesRead] = '\0';
+
+            if (strstr(buf, "start") == buf) {
+                startSampling();
+            } else if (strstr(buf, "stop") == buf) {
+                stopSampling();
+            } else if (strstr(buf, "status") == buf) {
+                reportStatus(clientConnection);
+            } else {
+                logError("WARN: Unknown command received, ignoring: %s\n", buf);
+            }
+        }
+
+        close(clientConnection);
+    }
+
+    close(listener);
+}
+
+void Controller::startSampling() {
+    JNIEnv *env = getJNIEnv(jvm_);
+
+    if (env == NULL) {
+        logError("ERROR: Failed to obtain JNI environment, cannot start sampling\n");
+        return;
+    }
+
+    profiler_->start(env);
+}
+
+void Controller::stopSampling() {
+    profiler_->stop();
+}
+
+void Controller::reportStatus(int clientConnection) {
+    bool samplingIsRunning = profiler_->isRunning();
+    // ensures there's space for status, log file path, comma, newline, and NUL
+    int bufSize = strlen(configuration_->logFilePath) + 10;
+    char buf[bufSize];
+
+    snprintf(buf, bufSize, "%s,%s\n", samplingIsRunning ? "started" : "stopped", configuration_->logFilePath);
+
+    int length = strlen(buf);
+
+    if (send(clientConnection, buf, length, 0) <= 0) {
+        logError("ERROR: Failed to respond to client: %s\n", strerror(errno));
+    }
+}

--- a/src/main/cpp/controller.h
+++ b/src/main/cpp/controller.h
@@ -1,0 +1,48 @@
+#ifndef HONEST_PROFILER_CONTROLLER_H
+#define HONEST_PROFILER_CONTROLLER_H
+
+#include "globals.h"
+#include "common.h"
+#include "profiler.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <jvmti.h>
+
+#define MAX_DATA_SIZE 100
+
+class Controller {
+public:
+    explicit Controller(JavaVM *jvm, jvmtiEnv *jvmti, Profiler *profiler, ConfigurationOptions *configuration) :
+            jvm_(jvm), jvmti_(jvmti), profiler_(profiler), configuration_(configuration), isRunning_(true) {
+
+    }
+
+    void start();
+
+    void stop();
+
+    void run();
+
+private:
+    JavaVM *jvm_;
+    jvmtiEnv *jvmti_;
+    Profiler *profiler_;
+    ConfigurationOptions *configuration_;
+    std::atomic_bool isRunning_;
+
+
+    void startSampling();
+
+    void stopSampling();
+
+    void reportStatus(int clientConnection);
+};
+
+#endif

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -11,6 +11,7 @@
 class Profiler;
 
 void logError(const char *__restrict format, ...);
+
 Profiler *getProfiler();
 
 const int DEFAULT_SAMPLING_INTERVAL = 1;
@@ -19,12 +20,16 @@ struct ConfigurationOptions {
     /** Interval in microseconds */
     int samplingIntervalMin, samplingIntervalMax;
     char* logFilePath;
+    char* host;
+    char* port;
     bool start;
 
     ConfigurationOptions() :
             samplingIntervalMin(DEFAULT_SAMPLING_INTERVAL),
             samplingIntervalMax(DEFAULT_SAMPLING_INTERVAL),
             logFilePath(NULL),
+            host(NULL),
+            port(NULL),
             start(true) {
     }
 };

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -10,29 +10,6 @@
 
 #endif
 
-static jthread newThread(JNIEnv *jniEnv) {
-    jclass thrClass;
-    jmethodID cid;
-    jthread res;
-
-    thrClass = jniEnv->FindClass("java/lang/Thread");
-    if (thrClass == NULL) {
-        logError("WARN: Cannot find Thread class\n");
-    }
-    cid = jniEnv->GetMethodID(thrClass, "<init>", "()V");
-    if (cid == NULL) {
-        logError("WARN: Cannot find Thread constructor method\n");
-    }
-    res = jniEnv->NewObject(thrClass, cid);
-    if (res == NULL) {
-        logError("WARN: Cannot create new Thread object\n");
-    } else {
-       jmethodID mid = jniEnv->GetMethodID(thrClass, "setName","(Ljava/lang/String;)V");
-       jniEnv->CallObjectMethod(res, mid, jniEnv->NewStringUTF("Honest Profiler Daemon Thread"));  
-    }
-    return res;
-}
-
 const uint MILLIS_IN_MICRO = 1000;
 
 void sleep_for_millis(uint period) {
@@ -86,7 +63,7 @@ void Processor::start(JNIEnv *jniEnv) {
     jvmtiError result;
 
     std::cout << "Starting sampling\n";
-    jthread thread = newThread(jniEnv);
+    jthread thread = newThread(jniEnv, "Honest Profiler Processing Thread");
     jvmtiStartFunction callback = callbackToRunProcessor;
     result = jvmti_->RunAgentThread(thread, callback, this, JVMTI_THREAD_NORM_PRIORITY);
 

--- a/src/main/cpp/processor.h
+++ b/src/main/cpp/processor.h
@@ -2,6 +2,7 @@
 #define PROCESSOR_H
 
 #include <jvmti.h>
+#include "common.h"
 #include "log_writer.h"
 #include "signal_handler.h"
 
@@ -10,7 +11,7 @@ class Processor {
 public:
     explicit Processor(jvmtiEnv* jvmti, LogWriter& logWriter,
             CircularQueue& buffer, SignalHandler& handler, int interval)
-            : jvmti_(jvmti), logWriter_(logWriter), buffer_(buffer), isRunning_(true), handler_(handler), interval_(interval) {
+            : jvmti_(jvmti), logWriter_(logWriter), buffer_(buffer), isRunning_(false), handler_(handler), interval_(interval) {
     }
 
     void start(JNIEnv *jniEnv);

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -70,7 +70,7 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
 
     JVMPI_CallTrace trace;
     trace.frames = frames;
-    JNIEnv *jniEnv = getJNIEnv();
+    JNIEnv *jniEnv = getJNIEnv(jvm_);
     if (jniEnv == NULL) {
     	trace.num_frames = -3; // ticks_unknown_not_Java
     } else {
@@ -80,16 +80,6 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
     }
     // log all samples, failures included, let the post processing sift through the data
   	buffer->push(trace);
-}
-
-JNIEnv *Profiler::getJNIEnv() {
-    JNIEnv *jniEnv = NULL;
-    int getEnvStat = jvm_->GetEnv((void **)&jniEnv, JNI_VERSION_1_6);
-    // check for issues
-    if (getEnvStat == JNI_EDETACHED || getEnvStat == JNI_EVERSION) {
-        jniEnv = NULL;
-    }
-    return jniEnv;
 }
 
 bool Profiler::start(JNIEnv *jniEnv) {

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -85,8 +85,6 @@ private:
             jvmtiEnv *jvmti,
             MethodListener &logWriter);
 
-    JNIEnv *getJNIEnv();
-
     DISALLOW_COPY_AND_ASSIGN(Profiler);
 };
 


### PR DESCRIPTION
- Enables out-of-process control of the sampling, eliminating the need to include the honest profiler JAR on the classpath of the Java application
- Adds a second agent thread that listens on a socket for control connections
- Control commands are `start`, `stop`, and `status`
- Status command will also print out the log file path