### PR TITLE
Fixing squid: S1602 Lamdbas containing only one statement should not nest this statement in a block

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/landing/LandingViewModel.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/landing/LandingViewModel.java
@@ -85,9 +85,8 @@ public class LandingViewModel implements MachineListener
     {
         logger.debug("Initializing LandingViewModel");
         toggleMachines.selectedToggleProperty()
-            .addListener((of, from, to) -> {
-                monitorButton.setDisable(to == null);
-            });
+            .addListener((of, from, to) ->
+                    monitorButton.setDisable(to == null));
         machines.forEach(this::displayMachine);
     }
 

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/web/WebsocketMachineAdapter.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/web/WebsocketMachineAdapter.java
@@ -48,9 +48,7 @@ public class WebsocketMachineAdapter implements MachineListener, Consumer<WebSoc
     @Override
     public void accept(WebSocketConnection connection)
     {
-        machines.forEach(machine -> {
-            connection.send(messages.addJavaVirtualMachine(machine));
-        });
+        machines.forEach(machine -> connection.send(messages.addJavaVirtualMachine(machine)));
     }
 
     @Override

--- a/src/test/java/com/insightfullogic/honest_profiler/core/filters/FilterParserTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/core/filters/FilterParserTest.java
@@ -35,10 +35,11 @@ public class FilterParserTest
 
         describe("filter parsing", it -> {
 
-            it.should("not remove anything for empty strings", expect -> {
-                expect.that(Filters.parse("")).hasSize(1)
-                    .contains(new ThreadSampleFilter());
-            });
+            it.should("not remove anything for empty strings", expect ->
+                    expect
+                       .that(Filters.parse(""))
+                       .hasSize(1)
+                       .contains(new ThreadSampleFilter()));
 
             it.should("parse total time filters", expect -> {
                 List<Filter> filters = Filters.parse("total time > 0.3;");
@@ -68,16 +69,11 @@ public class FilterParserTest
                 );
             });
 
-            it.should("validate time filters", expect -> {
-                expect.exception(FilterParseException.class, () -> {
-                    Filters.parse("self time > 1.543;");
-                });
-            });
+            it.should("validate time filters", expect ->
+                    expect.exception(FilterParseException.class, () -> Filters.parse("self time > 1.543;")));
 
             it.should("throw an exception when the input is nonsense", expect -> {
-                expect.exception(FilterParseException.class, () -> {
-                    Filters.parse("self dasdasds");
-                });
+                expect.exception(FilterParseException.class, () -> Filters.parse("self dasdasds"));
             });
 
         });

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/WebSocketMachineSourceTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/WebSocketMachineSourceTest.java
@@ -62,9 +62,7 @@ public class WebSocketMachineSourceTest
                 finder = new WebSocketMachineSource(logger, monitor, listener);
             });
 
-            it.should("initially know of no machines", expect -> {
-                verifyNoMoreInteractions(listener);
-            });
+            it.should("initially know of no machines", expect -> verifyNoMoreInteractions(listener));
 
             it.should("recognise a new machine", expect -> {
                 when:

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/sources/FileLogSourceTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/sources/FileLogSourceTest.java
@@ -35,35 +35,33 @@ public class FileLogSourceTest
 {
     {
 
-        describe("File Log Source", it -> {
-
+        describe("File Log Source", it ->
             it.should("Be able to read from updating files", expect -> {
-                // Given
-                File file = File.createTempFile("foo", ".bin");
-                file.deleteOnExit();
+            // Given
+            File file = File.createTempFile("foo", ".bin");
+            file.deleteOnExit();
+
+            // when
+            try (FileOutputStream stream = new FileOutputStream(file))
+            {
+                stream.write(1);
+                stream.flush();
+                FileLogSource source = new FileLogSource(file);
+
+                // then
+                ByteBuffer buffer = source.read();
+                expect.that(buffer.limit()).is(1)
+                    .and(buffer.get()).is((byte) 1);
 
                 // when
-                try (FileOutputStream stream = new FileOutputStream(file))
-                {
-                    stream.write(1);
-                    stream.flush();
-                    FileLogSource source = new FileLogSource(file);
+                stream.write(2);
+                stream.flush();
 
-                    // then
-                    ByteBuffer buffer = source.read();
-                    expect.that(buffer.limit()).is(1)
-                        .and(buffer.get()).is((byte) 1);
-
-                    // when
-                    stream.write(2);
-                    stream.flush();
-
-                    // then
-                    buffer = source.read();
-                    expect.that(buffer.limit()).isGreaterThanOrEqualTo(1)
-                        .and(buffer.get()).is((byte) 2);
-                }
-            });
-        });
+                // then
+                buffer = source.read();
+                expect.that(buffer.limit()).isGreaterThanOrEqualTo(1)
+                    .and(buffer.get()).is((byte) 2);
+            }
+        }));
 
     }}

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSourceTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSourceTest.java
@@ -20,28 +20,27 @@ public class LocalMachineSourceTest
             Logger logger = mock(Logger.class);
 
 
-            it.should("detect local machines", expect -> {
+            it.should("detect local machines", expect ->
                 AgentRunner.run("InfiniteExample", runner -> {
-                    final int expectedProcessId = runner.getProcessId();
-                    new LocalMachineSource(logger, new MachineListener()
+                final int expectedProcessId = runner.getProcessId();
+                new LocalMachineSource(logger, new MachineListener()
+                {
+                    @Override
+                    public void onNewMachine(final VirtualMachine machine)
                     {
-                        @Override
-                        public void onNewMachine(final VirtualMachine machine)
-                        {
-                            int machineProcessId = Integer.parseInt(machine.getId());
-                            expect.that(machine.isAgentLoaded()).is(machineProcessId == expectedProcessId);
-                        }
+                        int machineProcessId = Integer.parseInt(machine.getId());
+                        expect.that(machine.isAgentLoaded()).is(machineProcessId == expectedProcessId);
+                    }
 
-                        @Override
-                        public void onClosedMachine(final VirtualMachine machine)
-                        {
-                            expect.failure("Should never close VM " + machine);
-                        }
-                    }).discoverVirtualMachines();
-                });
-            });
+                    @Override
+                    public void onClosedMachine(final VirtualMachine machine)
+                    {
+                        expect.failure("Should never close VM " + machine);
+                    }
+                }).discoverVirtualMachines();
+            }));
 
-            it.should("detect no local machines if none are running", expect -> {
+            it.should("detect no local machines if none are running", expect ->
                 new LocalMachineSource(logger, new MachineListener()
                 {
                     @Override
@@ -55,8 +54,8 @@ public class LocalMachineSourceTest
                     {
                         expect.failure("Should never close VM " + machine);
                     }
-                }).discoverVirtualMachines();
-            });
+                }).discoverVirtualMachines()
+            );
 
         });
 

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/web/VirtualWebsocketMachineAdapterTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/web/VirtualWebsocketMachineAdapterTest.java
@@ -45,9 +45,8 @@ public class VirtualWebsocketMachineAdapterTest
                 adapter = new WebsocketMachineAdapter(clients, new MessageEncoder());
             });
 
-            it.should("Register for connections", expect -> {
-                verify(clients).setListener(adapter);
-            });
+            it.should("Register for connections", expect ->
+                    verify(clients).setListener(adapter));
 
             it.should("send information about added JVMs", expect -> {
                 adapter.onNewMachine(jvm);

--- a/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
@@ -62,39 +62,35 @@ public class AgentIntegrationTest
             });
 
             it.should("should result in a monitorable JVM", expect ->
-            {
-                AgentRunner.run("InfiniteExample", runner ->
-                {
-                    int seenTraceCount = 0;
+                    AgentRunner.run("InfiniteExample", runner ->
+                    {
+                        int seenTraceCount = 0;
 
-                    AtomicReference<Profile> lastProfile = discoverVirtualMachines();
+                        AtomicReference<Profile> lastProfile = discoverVirtualMachines();
 
-                    seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                        seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
 
-                    seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                        seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
 
-                    seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
-                });
-            });
+                        seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                    }));
 
             it.should("should be able to start/stop the JVM", expect ->
-            {
-                AgentRunner.run("InfiniteExample", "start=0", runner ->
-                {
-                    int seenTraceCount = 0;
+                    AgentRunner.run("InfiniteExample", "start=0", runner ->
+                    {
+                        int seenTraceCount = 0;
 
-                    AtomicReference<Profile> lastProfile = discoverVirtualMachines();
+                        AtomicReference<Profile> lastProfile = discoverVirtualMachines();
 
-                    seenTraceCount = expectNonIncreasingTraceCount(expect, seenTraceCount, lastProfile);
-                    runner.startProfiler();
+                        seenTraceCount = expectNonIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                        runner.startProfiler();
 
-                    seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
-                    runner.stopProfiler();
+                        seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                        runner.stopProfiler();
 
-                    seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
-                    seenTraceCount = expectNonIncreasingTraceCount(expect, seenTraceCount, lastProfile);
-                });
-            });
+                        seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                        seenTraceCount = expectNonIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                    }));
         });
 
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1602 - “Lamdbas containing only one statement should not nest this statement”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1602
Please let me know if you have any questions.
Soso Tughushi