### PR TITLE
fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/src/test/java/com/insightfullogic/honest_profiler/core/Util.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/core/Util.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 public class Util
 {
+    private Util(){ }
 
     public static File log0()
     {

--- a/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/ProfileFixtures.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/ProfileFixtures.java
@@ -25,6 +25,7 @@ import com.insightfullogic.honest_profiler.core.parser.Method;
 
 public class ProfileFixtures
 {
+    private ProfileFixtures(){ }
 
     public static final long printlnId = 5;
     public static final long appendId = 6;

--- a/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/VirtualMachineFixtures.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/VirtualMachineFixtures.java
@@ -6,7 +6,8 @@ import java.io.File;
 
 public class VirtualMachineFixtures
 {
-
+    private VirtualMachineFixtures(){ }
+    
     public static final VirtualMachine vmNoAgent = new VirtualMachine("0", "vm without agent", false, "");
     public static final VirtualMachine vmWithAgent = new VirtualMachine("1", "vm with agent", true, new File(".").getAbsolutePath());
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”.

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Soso Tughushi