### PR TITLE
General code fix 1

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleLogDumpApplication.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleLogDumpApplication.java
@@ -144,7 +144,7 @@ public class ConsoleLogDumpApplication
                     // bad sample dressed up as a frame
                     out.print("StackFrame: ");
                     indent(out);
-                    out.printf("%s::%s \n", boundMethod.className, boundMethod.methodName);
+                    out.printf("%s::%s %n", boundMethod.className, boundMethod.methodName);
                     Counter counter = errHistogram.computeIfAbsent(boundMethod.methodName, k -> new Counter());
                     counter.inc();
                 }
@@ -180,13 +180,13 @@ public class ConsoleLogDumpApplication
             @Override
             public void endOfLog()
             {
-                out.printf("Processed %d traces, %d faulty\n", traceidx, errCount);
+                out.printf("Processed %d traces, %d faulty%n", traceidx, errCount);
                 for (Map.Entry<String, Counter> e : errHistogram.entrySet())
                 {
                     final String errCode = e.getKey();
                     final int errCodeCount = e.getValue().i;
 
-                    out.printf("%-20s: %d \n", errCode, errCodeCount);
+                    out.printf("%-20s: %d %n", errCode, errCodeCount);
                 }
             }
         });

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/JavaFXApplication.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/JavaFXApplication.java
@@ -59,8 +59,6 @@ public class JavaFXApplication extends Application
     void createStart(Stage stage)
     {
         pico = registerComponents(stage);
-        WindowViewModel stageModel = pico.getComponent(WindowViewModel.class);
-        Parent parent = stageModel.displayStart();
         pico.start();
     }
 

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/sources/FileLogSource.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/sources/FileLogSource.java
@@ -44,14 +44,24 @@ public class FileLogSource implements LogSource
     public FileLogSource(final File file)
     {
         this.file = file;
+        RandomAccessFile randomAccessFile= null;
         try
         {
-            channel = new RandomAccessFile(file, "r").getChannel();
+            randomAccessFile = new RandomAccessFile(file, "r");
+            channel = randomAccessFile.getChannel();
             remapFile(channel.size());
         }
         catch (IOException e)
         {
             throw new CantReadFromSourceException(e);
+        }
+        finally {
+            if(randomAccessFile != null){
+                try {
+                    randomAccessFile.close();
+                }
+                catch(IOException ex){}
+            }
         }
     }
 

--- a/src/test/java/com/insightfullogic/honest_profiler/core/ConductorTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/core/ConductorTest.java
@@ -42,7 +42,6 @@ public class ConductorTest
 
             it.should("parse a basic log", expect -> {
                 LogEventListener listener = mock(LogEventListener.class);
-                LogSaver saver = mock(LogSaver.class);
                 Logger logger = mock(Logger.class);
                 LogParser parser = new LogParser(logger, listener);
                 Conductor consumer = new Conductor(logger, Util.log0Source(), parser, false);

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/WebSocketMachineSourceTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/WebSocketMachineSourceTest.java
@@ -52,7 +52,6 @@ public class WebSocketMachineSourceTest
             //DataConsumer dataConsumer = mock(DataConsumer.class);
             Monitor monitor = mock(Monitor.class);
             MachineListener listener = mock(MachineListener.class);
-            ProfileListener profileListener = mock(ProfileListener.class);
             Logger logger = mock(Logger.class);
 
             it.isSetupWith(() -> {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
squid:S1481 - Unused local variables should be removed.
squid:S2095 - Fixed rule 'Resources should be closed.

You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2275
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Soso Tughushi