### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/core/collector/NodeCollector.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/collector/NodeCollector.java
@@ -40,11 +40,6 @@ public final class NodeCollector
 
     private long methodId;
 
-    public int getNumberOfVisits()
-    {
-        return visits;
-    }
-
     private int visits;
 
     public NodeCollector(long methodId)
@@ -105,6 +100,12 @@ public final class NodeCollector
             .collect(toList());
 
         return new ProfileNode(method, timeShare, children);
+    }
+
+
+    public int getNumberOfVisits()
+    {
+        return visits;
     }
 
 }

--- a/src/main/java/com/insightfullogic/honest_profiler/core/filters/Filters.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/filters/Filters.java
@@ -38,11 +38,6 @@ public class Filters
 
     private int offset;
 
-    public static List<Filter> parse(String description)
-    {
-        return new Filters(description).parse();
-    }
-
     private Filters(String description)
     {
         filters = new ArrayList<>();
@@ -54,6 +49,11 @@ public class Filters
             description = description + ';';
         }
         this.description = description;
+    }
+
+    public static List<Filter> parse(String description)
+    {
+        return new Filters(description).parse();
     }
 
     private List<Filter> parse()

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleApplication.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleApplication.java
@@ -44,6 +44,13 @@ public class ConsoleApplication
     private File logLocation;
     private String filterDescription;
 
+    public ConsoleApplication(final Console error, final Console output)
+    {
+        this.output = output;
+        this.error = error;
+        ui = new ProfileView(output);
+    }
+
     public static void main(String[] args)
     {
         AnsiConsole.systemInstall();
@@ -60,13 +67,6 @@ public class ConsoleApplication
             System.err.println(e.getMessage());
             parser.printUsage(System.err);
         }
-    }
-
-    public ConsoleApplication(final Console error, final Console output)
-    {
-        this.output = output;
-        this.error = error;
-        ui = new ProfileView(output);
     }
 
     @Option(name = "-log", usage = "set the log that you want to parser or use")

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleLogDumpApplication.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleLogDumpApplication.java
@@ -58,6 +58,12 @@ public class ConsoleLogDumpApplication
 
     private File logLocation;
 
+    public ConsoleLogDumpApplication(final Console error, final Console output)
+    {
+        this.output = output;
+        this.error = error;
+    }
+
     public static void main(String[] args)
     {
         ConsoleLogDumpApplication entry = new ConsoleLogDumpApplication(() -> System.err, () -> System.out);
@@ -73,12 +79,6 @@ public class ConsoleLogDumpApplication
             System.err.println(e.getMessage());
             parser.printUsage(System.err);
         }
-    }
-
-    public ConsoleLogDumpApplication(final Console error, final Console output)
-    {
-        this.output = output;
-        this.error = error;
     }
 
     @Option(name = "-log", usage = "set the log that you want to parse or use", required = true)

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/profile/FlatViewModel.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/profile/FlatViewModel.java
@@ -55,6 +55,11 @@ public class FlatViewModel implements ProfileListener
     @FXML
     private TableColumn<FlatProfileEntry, Double> totalTimeShare;
 
+    public FlatViewModel()
+    {
+        flatProfile = FXCollections.observableArrayList();
+    }
+
     @FXML
     private void initialize()
     {
@@ -74,11 +79,6 @@ public class FlatViewModel implements ProfileListener
     {
         column.setCellValueFactory(new PropertyValueFactory<>(propertyName));
         column.setCellFactory(col -> new TimeShareTableCell());
-    }
-
-    public FlatViewModel()
-    {
-        flatProfile = FXCollections.observableArrayList();
     }
 
     @Override

--- a/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
@@ -46,6 +46,9 @@ import static org.hamcrest.Matchers.greaterThan;
 @RunWith(JunitSuiteRunner.class)
 public class AgentIntegrationTest
 {
+
+    private static Logger logger = LoggerFactory.getLogger(AgentIntegrationTest.class);
+
     private AtomicReference<FileLogSource> file = new AtomicReference<>();
 
     {
@@ -127,8 +130,6 @@ public class AgentIntegrationTest
 
         return lastProfile;
     }
-
-    private static Logger logger = LoggerFactory.getLogger(AgentIntegrationTest.class);
 
     private int expectIncreasingTraceCount(Expect expect, int seenTraceCount, AtomicReference<Profile> lastProfile)
     {

--- a/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/AgentRunner.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/AgentRunner.java
@@ -34,6 +34,18 @@ public class AgentRunner
 
     private static final Logger logger = LoggerFactory.getLogger(AgentRunner.class);
 
+    private final String className;
+    private final String args;
+
+    private Process process;
+    private int processId;
+
+    private AgentRunner(final String className, final String args)
+    {
+        this.className = className;
+        this.args = args;
+    }
+
     public static void run(final String className, final Consumer<AgentRunner> handler) throws IOException
     {
         run(className, null, handler);
@@ -53,18 +65,6 @@ public class AgentRunner
         {
             runner.stop();
         }
-    }
-
-    private final String className;
-    private final String args;
-
-    private Process process;
-    private int processId;
-
-    private AgentRunner(final String className, final String args)
-    {
-        this.className = className;
-        this.args = args;
     }
 
     private void start() throws IOException


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.
Soso Tughushi