### PR TITLE
Fix OS X build

### DIFF
--- a/src/test/cpp/test.h
+++ b/src/test/cpp/test.h
@@ -1,10 +1,6 @@
 #ifndef HONEST_PROFILER_TEST_H
 #define HONEST_PROFILER_TEST_H
 
-#ifdef __APPLE__
-#include <UnitTest++/UnitTest++/UnitTest++.h>
-#else
 #include <UnitTest++.h>
-#endif
 
 #endif //HONEST_PROFILER_TEST_H


### PR DESCRIPTION
Not sure what the reason was to have an Apple-specific path to `UnitTest++.h` with repeated occurrences of `UnitTest++`, but that Apple-specific path causes the build to fail for me under OS X. (I think I set up the UnitTest library following the instructions in the Wiki, but it's been a while so I'm not 100% sure anymore.)
