### PR TITLE
Test enhancement

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/core/platform/Platforms.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/platform/Platforms.java
@@ -1,0 +1,27 @@
+package com.insightfullogic.honest_profiler.core.platform;
+
+
+public class Platforms
+{
+    private Platforms() {}
+
+    public static String getDynamicLibraryExtension()
+    {
+        if (isOsx())
+        {
+            return ".dylib";
+        }
+        // Default is .so
+        return ".so";
+    }
+
+    private static boolean isOsx()
+    {
+        return getOsName().toUpperCase().contains("MAC");
+    }
+
+    private static String getOsName()
+    {
+        return System.getProperty("os.name");
+    }
+}

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSource.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSource.java
@@ -24,6 +24,7 @@ package com.insightfullogic.honest_profiler.ports.sources;
 import com.insightfullogic.honest_profiler.core.MachineListener;
 import com.insightfullogic.honest_profiler.core.ThreadedAgent;
 import com.insightfullogic.honest_profiler.core.sources.VirtualMachine;
+import com.insightfullogic.honest_profiler.core.platform.Platforms;
 import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.VirtualMachineDescriptor;
 import org.slf4j.Logger;
@@ -41,7 +42,7 @@ public class LocalMachineSource
 {
 
     private static final String VM_ARGS = "sun.jvm.args";
-    private static final String AGENT_NAME = "liblagent.so";
+    private static final String AGENT_NAME = "liblagent" + Platforms.getDynamicLibraryExtension();
     private static final String USER_DIR = "user.dir";
     private static final long DEFAULT_SLEEP_PERIOD = 500;
 

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/console/ConsoleApplicationTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/console/ConsoleApplicationTest.java
@@ -51,10 +51,10 @@ public class ConsoleApplicationTest
                 profiler.run();
 
                 then:
-                output.outputContains("PrintStream.printf");
+                output.outputContains("PrintStream::printf");
                 output.outputContains("100.0");
 
-                output.outputContains("PrintStream.append");
+                output.outputContains("PrintStream::append");
                 output.outputContains("100.0");
 
                 output.outputContains("Printing Profile for:");

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSourceTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSourceTest.java
@@ -21,7 +21,7 @@ public class LocalMachineSourceTest
 
 
             it.should("detect local machines", expect -> {
-                AgentRunner.run("InfiniteExample", "interval=100", runner -> {
+                AgentRunner.run("InfiniteExample", AgentRunner.DEFAULT_AGENT_INTERVAL, runner -> {
                     final int expectedProcessId = runner.getProcessId();
                     new LocalMachineSource(logger, new MachineListener()
                     {

--- a/src/test/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSourceTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/ports/sources/LocalMachineSourceTest.java
@@ -21,7 +21,7 @@ public class LocalMachineSourceTest
 
 
             it.should("detect local machines", expect -> {
-                AgentRunner.run("InfiniteExample", runner -> {
+                AgentRunner.run("InfiniteExample", "interval=100", runner -> {
                     final int expectedProcessId = runner.getProcessId();
                     new LocalMachineSource(logger, new MachineListener()
                     {

--- a/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
@@ -63,7 +63,8 @@ public class AgentIntegrationTest
 
             it.should("should result in a monitorable JVM", expect ->
             {
-                AgentRunner.run("InfiniteExample", "interval=100", runner ->
+                AgentRunner.run("InfiniteExample", AgentRunner.DEFAULT_AGENT_INTERVAL,
+                        runner ->
                 {
                     int seenTraceCount = 0;
 
@@ -79,7 +80,8 @@ public class AgentIntegrationTest
 
             it.should("should be able to start/stop the JVM", expect ->
             {
-                AgentRunner.run("InfiniteExample", "start=0,interval=100", runner ->
+                AgentRunner.run("InfiniteExample", new String[] { "start=0", AgentRunner.DEFAULT_AGENT_INTERVAL },
+                        runner ->
                 {
                     int seenTraceCount = 0;
 

--- a/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
@@ -63,7 +63,7 @@ public class AgentIntegrationTest
 
             it.should("should result in a monitorable JVM", expect ->
             {
-                AgentRunner.run("InfiniteExample", runner ->
+                AgentRunner.run("InfiniteExample", "interval=100", runner ->
                 {
                     int seenTraceCount = 0;
 
@@ -79,7 +79,7 @@ public class AgentIntegrationTest
 
             it.should("should be able to start/stop the JVM", expect ->
             {
-                AgentRunner.run("InfiniteExample", "start=0", runner ->
+                AgentRunner.run("InfiniteExample", "start=0,interval=100", runner ->
                 {
                     int seenTraceCount = 0;
 

--- a/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/AgentRunner.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/AgentRunner.java
@@ -21,6 +21,8 @@
  **/
 package com.insightfullogic.honest_profiler.testing_utilities;
 
+import com.insightfullogic.honest_profiler.core.platform.Platforms;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +78,7 @@ public class AgentRunner
     private void startProcess() throws IOException
     {
         String java = System.getProperty("java.home") + "/bin/java";
-        String agentArg = "-agentpath:build/liblagent.so" + (args != null ? "=" + args : "");
+        String agentArg = "-agentpath:build/liblagent" + Platforms.getDynamicLibraryExtension() + (args != null ? "=" + args : "");
         // Eg: java -agentpath:build/liblagent.so -cp target/classes/ InfiniteExample
         process = new ProcessBuilder()
             .command(java, agentArg, "-cp", "target/classes/", className)

--- a/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/AgentRunner.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/AgentRunner.java
@@ -35,10 +35,18 @@ public class AgentRunner
 {
 
     private static final Logger logger = LoggerFactory.getLogger(AgentRunner.class);
+    public static final String DEFAULT_AGENT_INTERVAL = "interval=100";
 
     public static void run(final String className, final Consumer<AgentRunner> handler) throws IOException
     {
-        run(className, null, handler);
+        run(className, (String) null, handler);
+    }
+
+    public static void run(final String className,
+                           final String[] args,
+                           final Consumer<AgentRunner> handler) throws IOException
+    {
+        run(className, String.join(",", args), handler);
     }
 
     public static void run(final String className,


### PR DESCRIPTION
Try build/run honest-profiler on my macbook and had found some problem.

1. That unit test sometimes success, but sometimes failed. It seams that subprocess running InfiniteExample with profile agent that used too much CPU and cause the unit test failed.
So I add agent argument: interval=100 that will decrease the cpu usage and pass the test.

2. The binary's extension for MacOS is dylib, so I create a class named Platforms for some platform specific constant/config.

3. Update some unit test