### PR TITLE
Use case-sensitive name for fxml for Window enum

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/WindowViewModel.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/WindowViewModel.java
@@ -32,12 +32,18 @@ public class WindowViewModel
 
     public enum Window
     {
-        LANDING,
-        PROFILE;
+        LANDING("Landing"),
+        PROFILE("Profile");
+
+        private final String fxmlPrefix;
+
+        Window(String fxmlPrefix) {
+            this.fxmlPrefix = fxmlPrefix;
+        }
 
         private String getFxmlFile()
         {
-            return name() + "View.fxml";
+            return fxmlPrefix + "View.fxml";
         }
     }
 


### PR DESCRIPTION
Without this fix I was seeing this:

```
Exception in thread "main" java.lang.RuntimeException: Exception in Application start method
	at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:917)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication$155(LauncherImpl.java:182)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: Location is not set.
	at javafx.fxml.FXMLLoader.loadImpl(FXMLLoader.java:2434)
	at javafx.fxml.FXMLLoader.load(FXMLLoader.java:2409)
	at com.insightfullogic.honest_profiler.ports.javafx.PicoFXLoader.load(PicoFXLoader.java:46)
	at com.insightfullogic.honest_profiler.ports.javafx.WindowViewModel.display(WindowViewModel.java:55)
	at com.insightfullogic.honest_profiler.ports.javafx.WindowViewModel.displayStart(WindowViewModel.java:64)
	at com.insightfullogic.honest_profiler.ports.javafx.JavaFXApplication.createStart(JavaFXApplication.java:63)
	at com.insightfullogic.honest_profiler.ports.javafx.JavaFXApplication.start(JavaFXApplication.java:49)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$162(LauncherImpl.java:863)
	at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$175(PlatformImpl.java:326)
	at com.sun.javafx.application.PlatformImpl.lambda$null$173(PlatformImpl.java:295)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$174(PlatformImpl.java:294)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$null$49(GtkApplication.java:139)
	... 1 more
```