### PR TITLE
Add getters and setters to agent's Profiler class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC "src/main/cpp")
 set(SRC_TEST "src/test/cpp")
 set(BIN "build")
 set(OUTPUT "lagent")
+set(OUTPUT_TEST "lagent.test")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BIN})
 
 ##########################################################
@@ -65,7 +66,8 @@ set(SOURCE_FILES
     ${SRC}/processor.h
     ${SRC}/profiler.cpp
     ${SRC}/profiler.h
-    ${SRC}/stacktraces.h)
+    ${SRC}/stacktraces.h
+    ${SRC}/trace.h)
 
 set(TEST_FILES
     ${SRC_TEST}/fixtures.h
@@ -73,7 +75,8 @@ set(TEST_FILES
     ${SRC_TEST}/test.cpp
     ${SRC_TEST}/test_log_writer.cpp
     ${SRC_TEST}/test_agent.cpp
-    ${SRC_TEST}/test.h)
+    ${SRC_TEST}/test.h
+    ${SRC_TEST}/test_profiler_config.cpp)
 
 
 ##########################################################
@@ -116,19 +119,26 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GLOBAL_WARNINGS} ${GLOBAL_COPTS} -pthr
 
 add_library(${OUTPUT} SHARED ${SOURCE_FILES})
 
+# Unit test build
+add_library(${OUTPUT_TEST} SHARED ${SOURCE_FILES})
+target_compile_definitions(${OUTPUT_TEST} PRIVATE TEST_PROFILER=1 ENABLE_TRACING=1)
+
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD") 
     target_link_libraries(${OUTPUT} ${JNI_LIBRARIES})
+    target_link_libraries(${OUTPUT_TEST} ${JNI_LIBRARIES})
 else()
     target_link_libraries(${OUTPUT} ${JNI_LIBRARIES} dl)
+    target_link_libraries(${OUTPUT_TEST} ${JNI_LIBRARIES} dl)
 endif()
 
 add_executable(unitTests ${TEST_FILES})
+target_compile_definitions(unitTests PRIVATE TEST_PROFILER=1 ENABLE_TRACING=1)
 
 if (DEFINED ENV{UNITTEST_LIBRARIES})
     message("User has configured " $ENV{UNITTEST_LIBRARIES} " as the unit test libraries")
-    target_link_libraries(unitTests ${OUTPUT} $ENV{UNITTEST_LIBRARIES})
+    target_link_libraries(unitTests ${OUTPUT_TEST} $ENV{UNITTEST_LIBRARIES})
 else()
-    target_link_libraries(unitTests ${OUTPUT} ${unittest++_LIBRARIES})
+    target_link_libraries(unitTests ${OUTPUT_TEST} ${unittest++_LIBRARIES})
 endif()
 
 # make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ set(SRC "src/main/cpp")
 set(SRC_TEST "src/test/cpp")
 set(BIN "build")
 set(OUTPUT "lagent")
-set(OUTPUT_TEST "lagent.test")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BIN})
 
 ##########################################################
@@ -112,6 +111,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(GLOBAL_WARNINGS, "${GLOBAL_WARNINGS} -Wno-unknown-pragmas -Wno-builtin-macro-redefined -Wl,-fatal_warnings")
 endif()
 
+# to enable tracing add: -DENABLE_TRACING
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GLOBAL_WARNINGS} ${GLOBAL_COPTS} -pthread -std=c++0x")
 
 ##########################################################
@@ -119,26 +119,19 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GLOBAL_WARNINGS} ${GLOBAL_COPTS} -pthr
 
 add_library(${OUTPUT} SHARED ${SOURCE_FILES})
 
-# Unit test build
-add_library(${OUTPUT_TEST} SHARED ${SOURCE_FILES})
-target_compile_definitions(${OUTPUT_TEST} PRIVATE TEST_PROFILER=1 ENABLE_TRACING=1)
-
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD") 
     target_link_libraries(${OUTPUT} ${JNI_LIBRARIES})
-    target_link_libraries(${OUTPUT_TEST} ${JNI_LIBRARIES})
 else()
     target_link_libraries(${OUTPUT} ${JNI_LIBRARIES} dl)
-    target_link_libraries(${OUTPUT_TEST} ${JNI_LIBRARIES} dl)
 endif()
 
 add_executable(unitTests ${TEST_FILES})
-target_compile_definitions(unitTests PRIVATE TEST_PROFILER=1 ENABLE_TRACING=1)
 
 if (DEFINED ENV{UNITTEST_LIBRARIES})
     message("User has configured " $ENV{UNITTEST_LIBRARIES} " as the unit test libraries")
-    target_link_libraries(unitTests ${OUTPUT_TEST} $ENV{UNITTEST_LIBRARIES})
+    target_link_libraries(unitTests ${OUTPUT} $ENV{UNITTEST_LIBRARIES})
 else()
-    target_link_libraries(unitTests ${OUTPUT_TEST} ${unittest++_LIBRARIES})
+    target_link_libraries(unitTests ${OUTPUT} ${unittest++_LIBRARIES})
 endif()
 
 # make test

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -250,7 +250,7 @@ static bool RegisterJvmti(jvmtiEnv *jvmti) {
     return true;
 }
 
-static char *safe_copy_string(const char *value, const char *next) {
+char *safe_copy_string(const char *value, const char *next) {
     size_t size = (next == 0) ? strlen(value) : (size_t) (next - value);
     char *dest = (char *) malloc((size + 1) * sizeof(char));
 

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -261,6 +261,10 @@ char *safe_copy_string(const char *value, const char *next) {
     return dest;
 }
 
+void safe_free_string(char *value) {
+    free(value);
+}
+
 static void parseArguments(char *options, ConfigurationOptions &configuration) {
     char* next = options;
     for (char *key = options; next != NULL; key = next + 1) {
@@ -341,11 +345,8 @@ AGENTEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved
 AGENTEXPORT void JNICALL Agent_OnUnload(JavaVM *vm) {
     IMPLICITLY_USE(vm);
 
-    controller->stop();
-
-    delete controller;
-    delete prof;
-    delete CONFIGURATION;
+    if (controller->isRunning())
+        controller->stop();
 }
 
 void bootstrapHandle(int signum, siginfo_t *info, void *context) {

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -366,3 +366,7 @@ void logError(const char *__restrict format, ...) {
 Profiler *getProfiler() {
     return prof;
 }
+
+void setProfiler(Profiler *p) {
+    prof = p;
+}

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -261,10 +261,11 @@ char *safe_copy_string(const char *value, const char *next) {
     return dest;
 }
 
-void safe_free_string(char *value) {
+void safe_free_string(char *&value) {
     /** Prevent Profiler from calling delete/free explicitly when string goes
      *  out of the scope. */
     free(value);
+    value = NULL;
 }
 
 static void parseArguments(char *options, ConfigurationOptions &configuration) {

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -262,6 +262,8 @@ char *safe_copy_string(const char *value, const char *next) {
 }
 
 void safe_free_string(char *value) {
+    /** Prevent Profiler from calling delete/free explicitly when string goes
+     *  out of the scope. */
     free(value);
 }
 

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -194,8 +194,9 @@ void JNICALL OnThreadStart(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread)
         if (error == JNI_OK) {
             if (strcmp(thread_info.name, "main") == 0) {
                 main_started = true;
-                if (CONFIGURATION->start)
+                if (CONFIGURATION->start) {
                     prof->start(jni_env);
+                }
             }
         }
     }

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -290,9 +290,7 @@ static void parseArguments(char *options, ConfigurationOptions &configuration) {
             } else if (strstr(key, "port") == key) {
                 configuration.port = safe_copy_string(value, next);
             } else if (strstr(key, "maxFrames") == key) {
-                int framesCandidate = atoi(value);
-                if (framesCandidate > 0 && framesCandidate <= MAX_FRAMES_TO_CAPTURE)
-                    configuration.maxFramesToCapture = framesCandidate;
+                configuration.maxFramesToCapture = atoi(value);
             } else {
                 logError("WARN: Unknown configuration option: %s\n", key);
             }

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -88,7 +88,8 @@ void JNICALL OnVMDeath(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
     IMPLICITLY_USE(jvmti_env);
     IMPLICITLY_USE(jni_env);
 
-    prof->stop();
+    if (prof->isRunning())
+        prof->stop();
 }
 
 static bool PrepareJvmti(jvmtiEnv *jvmti) {
@@ -341,6 +342,10 @@ AGENTEXPORT void JNICALL Agent_OnUnload(JavaVM *vm) {
     IMPLICITLY_USE(vm);
 
     controller->stop();
+
+    delete controller;
+    delete prof;
+    delete CONFIGURATION;
 }
 
 void bootstrapHandle(int signum, siginfo_t *info, void *context) {

--- a/src/main/cpp/control.cpp
+++ b/src/main/cpp/control.cpp
@@ -44,3 +44,58 @@ JNIEXPORT jboolean JNICALL Java_com_insightfullogic_honest_1profiler_core_contro
 
     return prof->isRunning();
 }
+
+extern "C"
+JNIEXPORT jint JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_getSamplingIntervalMin(JNIEnv *env, jclass klass) {
+    Profiler *prof = getProfiler();
+
+    return prof->getSamplingIntervalMin();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_getSamplingIntervalMax(JNIEnv *env, jclass klass) {
+    Profiler *prof = getProfiler();
+
+    return prof->getSamplingIntervalMax();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_getMaxFramesToCapture(JNIEnv *env, jclass klass) {
+    Profiler *prof = getProfiler();
+
+    return prof->getMaxFramesToCapture();
+}
+
+extern "C"
+JNIEXPORT jstring JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_getFilePath(JNIEnv *env, jclass klass) {
+    Profiler *prof = getProfiler();
+
+    return env->NewStringUTF(prof->getFilePath());
+}
+
+extern "C"
+JNIEXPORT void JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_setFilePath(JNIEnv *env, jclass klass, jstring filePath) {
+    Profiler *prof = getProfiler();
+
+    if (filePath == NULL) {
+    	prof->setFilePath(NULL);
+    } else {
+    	const char *nativeString = env->GetStringUTFChars(filePath, 0);
+    	prof->setFilePath(safe_copy_string(nativeString, NULL));
+    	env->ReleaseStringUTFChars(filePath, nativeString);
+    }
+}
+
+extern "C"
+JNIEXPORT void JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_setSamplingInterval(JNIEnv *env, jclass klass, jint intervalMin, jint intervalMax) {
+    Profiler *prof = getProfiler();
+
+    prof->setSamplingInterval(intervalMin > 0 ? intervalMin : 1, intervalMax > 0 ? intervalMax : 1);
+}
+
+extern "C"
+JNIEXPORT void JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_setMaxFramesToCapture(JNIEnv *env, jclass klass, jint maxFramesToCapture) {
+    Profiler *prof = getProfiler();
+
+    prof->setMaxFramesToCapture(maxFramesToCapture > 0 && maxFramesToCapture <= MAX_FRAMES_TO_CAPTURE ? maxFramesToCapture : DEFAULT_MAX_FRAMES_TO_CAPTURE);
+}

--- a/src/main/cpp/control.cpp
+++ b/src/main/cpp/control.cpp
@@ -90,12 +90,12 @@ extern "C"
 JNIEXPORT void JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_setSamplingInterval(JNIEnv *env, jclass klass, jint intervalMin, jint intervalMax) {
     Profiler *prof = getProfiler();
 
-    prof->setSamplingInterval(intervalMin > 0 ? intervalMin : 1, intervalMax > 0 ? intervalMax : 1);
+    prof->setSamplingInterval(intervalMin, intervalMax);
 }
 
 extern "C"
 JNIEXPORT void JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_setMaxFramesToCapture(JNIEnv *env, jclass klass, jint maxFramesToCapture) {
     Profiler *prof = getProfiler();
 
-    prof->setMaxFramesToCapture(maxFramesToCapture > 0 && maxFramesToCapture <= MAX_FRAMES_TO_CAPTURE ? maxFramesToCapture : DEFAULT_MAX_FRAMES_TO_CAPTURE);
+    prof->setMaxFramesToCapture(maxFramesToCapture);
 }

--- a/src/main/cpp/control.cpp
+++ b/src/main/cpp/control.cpp
@@ -70,7 +70,7 @@ extern "C"
 JNIEXPORT jstring JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Agent_getFilePath(JNIEnv *env, jclass klass) {
     Profiler *prof = getProfiler();
 
-    return env->NewStringUTF(prof->getFilePath());
+    return env->NewStringUTF(prof->getFilePath().c_str());
 }
 
 extern "C"
@@ -81,7 +81,7 @@ JNIEXPORT void JNICALL Java_com_insightfullogic_honest_1profiler_core_control_Ag
     	prof->setFilePath(NULL);
     } else {
     	const char *nativeString = env->GetStringUTFChars(filePath, 0);
-    	prof->setFilePath(safe_copy_string(nativeString, NULL));
+    	prof->setFilePath((char*)nativeString);
     	env->ReleaseStringUTFChars(filePath, nativeString);
     }
 }

--- a/src/main/cpp/controller.cpp
+++ b/src/main/cpp/controller.cpp
@@ -104,7 +104,7 @@ void Controller::run() {
                 reportStatus(clientConnection);
             } else if (strstr(buf, "get ") == buf) {
                 getProfilerParam(clientConnection, buf + 4);
-            } else if (strstr(buf, "put ") == buf) {
+            } else if (strstr(buf, "set ") == buf) {
                 setProfilerParam(buf + 4);
             } else {
                 logError("WARN: Unknown command received, ignoring: %s\n", buf);

--- a/src/main/cpp/controller.cpp
+++ b/src/main/cpp/controller.cpp
@@ -135,7 +135,8 @@ void Controller::stopSampling() {
 void Controller::reportStatus(int clientConnection) {
     bool samplingIsRunning = profiler_->isRunning();
     // ensures there's space for status, log file path, comma, newline, and NULL
-    char *logFilePath = profiler_->getFilePath();
+    std::string filePath = profiler_->getFilePath();
+    const char *logFilePath = filePath.c_str();
     int bufSize = strlen(logFilePath) + 10;
     char buf[bufSize];
 
@@ -186,8 +187,7 @@ void Controller::setProfilerParam(char *paramDesc) {
 
     if (command == "logPath") {
         input >> stringArg;
-        char *newPath = safe_copy_string(stringArg.c_str(), NULL);
-        profiler_->setFilePath(newPath);
+        profiler_->setFilePath((char*)stringArg.c_str());
     } else {
         input >> numericArg1;
         if (command == "intervalMin") {

--- a/src/main/cpp/controller.cpp
+++ b/src/main/cpp/controller.cpp
@@ -40,6 +40,10 @@ void Controller::stop() {
     isRunning_.store(false);
 }
 
+bool Controller::isRunning() const {
+    return isRunning_.load();
+}
+
 void Controller::run() {
     struct addrinfo hints, *res;
     char buf[MAX_DATA_SIZE];
@@ -98,6 +102,10 @@ void Controller::run() {
                 stopSampling();
             } else if (strstr(buf, "status") == buf) {
                 reportStatus(clientConnection);
+            } else if (strstr(buf, "get ") == buf) {
+                getProfilerParam(clientConnection, buf + 4);
+            } else if (strstr(buf, "put ") == buf) {
+                setProfilerParam(buf + 4);
             } else {
                 logError("WARN: Unknown command received, ignoring: %s\n", buf);
             }
@@ -126,15 +134,73 @@ void Controller::stopSampling() {
 
 void Controller::reportStatus(int clientConnection) {
     bool samplingIsRunning = profiler_->isRunning();
-    // ensures there's space for status, log file path, comma, newline, and NUL
-    int bufSize = strlen(configuration_->logFilePath) + 10;
+    // ensures there's space for status, log file path, comma, newline, and NULL
+    char *logFilePath = profiler_->getFilePath();
+    int bufSize = strlen(logFilePath) + 10;
     char buf[bufSize];
 
-    snprintf(buf, bufSize, "%s,%s\n", samplingIsRunning ? "started" : "stopped", configuration_->logFilePath);
+    snprintf(buf, bufSize, "%s,%s\n", samplingIsRunning ? "started" : "stopped", logFilePath);
 
     int length = strlen(buf);
 
     if (send(clientConnection, buf, length, 0) <= 0) {
         logError("ERROR: Failed to respond to client: %s\n", strerror(errno));
+    }
+}
+
+void Controller::getProfilerParam(int clientConnection, char *param) {
+    std::stringstream buffer;
+    if (strstr(param, "intervalMin") == param) {
+        buffer << profiler_->getSamplingIntervalMin();
+    } else if (strstr(param, "intervalMax") == param) {
+        buffer << profiler_->getSamplingIntervalMax();
+    } else if (strstr(param, "interval") == param) {
+        buffer << profiler_->getSamplingIntervalMin() 
+            << ' ' 
+            << profiler_->getSamplingIntervalMax();
+    } else if (strstr(param, "maxFrames") == param) {
+        buffer << profiler_->getMaxFramesToCapture();
+    } else if (strstr(param, "logPath") == param) {
+        buffer << profiler_->getFilePath();
+    } else {
+        logError("WARN: Unknown parameter, ignoring: %s\n", param);
+        return;
+    }
+
+    buffer << '\n';
+    std::string content = buffer.str();
+    if (send(clientConnection, content.c_str(), content.size(), 0) <= 0) {
+        logError("ERROR: Failed to respond to client: %s\n", strerror(errno));
+    }
+}
+
+void Controller::setProfilerParam(char *paramDesc) {
+    std::istringstream input(paramDesc);
+    input >> std::ws;
+
+    std::string command;
+    int numericArg1, numericArg2;
+    std::string stringArg;
+
+    input >> command;
+
+    if (command == "logPath") {
+        input >> stringArg;
+        char *newPath = safe_copy_string(stringArg.c_str(), NULL);
+        profiler_->setFilePath(newPath);
+    } else {
+        input >> numericArg1;
+        if (command == "intervalMin") {
+            profiler_->setSamplingInterval(numericArg1, profiler_->getSamplingIntervalMax());
+        } else if (command == "intervalMax") {
+            profiler_->setSamplingInterval(profiler_->getSamplingIntervalMin(), numericArg1);
+        } else if (command == "maxFrames") {
+            profiler_->setMaxFramesToCapture(numericArg1);
+        } else if (command == "interval") {
+            input >> numericArg2;
+            profiler_->setSamplingInterval(numericArg1, numericArg2);
+        } else {
+            logError("WARN: Unknown command, ignoring: %s\n", command.c_str());
+        }
     }
 }

--- a/src/main/cpp/controller.h
+++ b/src/main/cpp/controller.h
@@ -30,6 +30,8 @@ public:
 
     void run();
 
+    bool isRunning() const;
+
 private:
     JavaVM *jvm_;
     jvmtiEnv *jvmti_;
@@ -43,6 +45,10 @@ private:
     void stopSampling();
 
     void reportStatus(int clientConnection);
+
+    void getProfilerParam(int clientConnection, char *param);
+
+    void setProfilerParam(char *paramDesc);
 };
 
 #endif

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -35,6 +35,16 @@ struct ConfigurationOptions {
             start(true),
             maxFramesToCapture(DEFAULT_MAX_FRAMES_TO_CAPTURE) {
     }
+
+    ConfigurationOptions(const ConfigurationOptions &conf) :
+            samplingIntervalMin(conf.samplingIntervalMin),
+            samplingIntervalMax(conf.samplingIntervalMax),
+            logFilePath(conf.logFilePath),
+            host(conf.host),
+            port(conf.port),
+            start(conf.start),
+            maxFramesToCapture(conf.maxFramesToCapture) {
+    }
 };
 
 #define AGENTEXPORT __attribute__((visibility("default"))) JNIEXPORT

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -26,6 +26,9 @@ const int MAX_FRAMES_TO_CAPTURE = 512;
   #define STATIC_ARRAY(NAME, TYPE, SIZE, MAXSZ) TYPE NAME[SIZE]
 #endif
 
+char *safe_copy_string(const char *value, const char *next);
+void safe_free_string(char *value);
+
 struct ConfigurationOptions {
     /** Interval in microseconds */
     int samplingIntervalMin, samplingIntervalMax;
@@ -46,9 +49,9 @@ struct ConfigurationOptions {
     }
 
     virtual ~ConfigurationOptions() {
-      if (logFilePath) delete logFilePath;
-      if (host) delete host;
-      if (port) delete port;
+      if (logFilePath) safe_free_string(logFilePath);
+      if (host) safe_free_string(host);
+      if (port) safe_free_string(port);
     }
 };
 
@@ -168,7 +171,5 @@ public:
 };
 
 void bootstrapHandle(int signum, siginfo_t *info, void *context);
-
-char *safe_copy_string(const char *value, const char *next);
 
 #endif // GLOBALS_H

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -13,6 +13,7 @@ class Profiler;
 void logError(const char *__restrict format, ...);
 
 Profiler *getProfiler();
+void setProfiler(Profiler *p);
 
 const int DEFAULT_SAMPLING_INTERVAL = 1;
 const int DEFAULT_MAX_FRAMES_TO_CAPTURE = 128;

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -173,4 +173,6 @@ public:
 
 void bootstrapHandle(int signum, siginfo_t *info, void *context);
 
+char *safe_copy_string(const char *value, const char *next);
+
 #endif // GLOBALS_H

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -45,14 +45,10 @@ struct ConfigurationOptions {
             maxFramesToCapture(DEFAULT_MAX_FRAMES_TO_CAPTURE) {
     }
 
-    ConfigurationOptions(const ConfigurationOptions &conf) :
-            samplingIntervalMin(conf.samplingIntervalMin),
-            samplingIntervalMax(conf.samplingIntervalMax),
-            logFilePath(conf.logFilePath),
-            host(conf.host),
-            port(conf.port),
-            start(conf.start),
-            maxFramesToCapture(conf.maxFramesToCapture) {
+    virtual ~ConfigurationOptions() {
+      if (logFilePath) delete logFilePath;
+      if (host) delete host;
+      if (port) delete port;
     }
 };
 

--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -27,7 +27,7 @@ const int MAX_FRAMES_TO_CAPTURE = 512;
 #endif
 
 char *safe_copy_string(const char *value, const char *next);
-void safe_free_string(char *value);
+void safe_free_string(char *&value);
 
 struct ConfigurationOptions {
     /** Interval in microseconds */

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -67,7 +67,6 @@ void Processor::start(JNIEnv *jniEnv) {
     jthread thread = newThread(jniEnv, "Honest Profiler Processing Thread");
     jvmtiStartFunction callback = callbackToRunProcessor;
     result = jvmti_->RunAgentThread(thread, callback, this, JVMTI_THREAD_NORM_PRIORITY);
-
     if (result != JVMTI_ERROR_NONE) {
         logError("ERROR: Running agent thread failed with: %d\n", result);
     }

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -20,6 +20,12 @@ void sleep_for_millis(uint period) {
 #endif
 }
 
+TRACE_DEFINE_BEGIN(Processor, kTraceProcessorTotal)
+    TRACE_DEFINE("start processor")
+    TRACE_DEFINE("stop processor")
+    TRACE_DEFINE("chech that processor is running")
+TRACE_DEFINE_END(Processor, kTraceProcessorTotal);
+
 void Processor::run() {
     int popped = 0;
 
@@ -43,6 +49,8 @@ void Processor::run() {
     }
 
     handler_.stopSigprof();
+    workerDone.clear(std::memory_order_relaxed);
+    // no shared data access after this point, can be safely deleted
 }
 
 void callbackToRunProcessor(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg) {
@@ -60,10 +68,12 @@ void callbackToRunProcessor(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg) {
 }
 
 void Processor::start(JNIEnv *jniEnv) {
+    TRACE(Processor, kTraceProcessorStart);
     jvmtiError result;
 
     std::cout << "Starting sampling\n";
     isRunning_.store(true);
+    workerDone.test_and_set(std::memory_order_relaxed); // initial is true
     jthread thread = newThread(jniEnv, "Honest Profiler Processing Thread");
     jvmtiStartFunction callback = callbackToRunProcessor;
     result = jvmti_->RunAgentThread(thread, callback, this, JVMTI_THREAD_NORM_PRIORITY);
@@ -73,10 +83,14 @@ void Processor::start(JNIEnv *jniEnv) {
 }
 
 void Processor::stop() {
+    TRACE(Processor, kTraceProcessorStop);
+
     isRunning_.store(false);
     std::cout << "Stopping sampling\n";
+    while (workerDone.test_and_set(std::memory_order_relaxed)) sched_yield();
 }
 
 bool Processor::isRunning() const {
+    TRACE(Processor, kTraceProcessorRunning);
     return isRunning_.load();
 }

--- a/src/main/cpp/processor.h
+++ b/src/main/cpp/processor.h
@@ -6,6 +6,17 @@
 #include "log_writer.h"
 #include "signal_handler.h"
 
+#include "trace.h"
+
+const int kTraceProcessorTotal = 3;
+
+const int kTraceProcessorStart = 0;
+const int kTraceProcessorStop = 1;
+const int kTraceProcessorRunning = 2;
+
+TRACE_DECLARE(Processor, kTraceProcessorTotal);
+
+
 class Processor {
 
 public:
@@ -30,6 +41,8 @@ private:
     CircularQueue& buffer_;
 
     std::atomic_bool isRunning_;
+
+    std::atomic_flag workerDone;
 
     SignalHandler& handler_;
 

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -324,7 +324,6 @@ void Profiler::configure() {
 #else
     bool needsUpdate = processorMock == NULL;
 #endif
-
     needsUpdate = needsUpdate || configuration_->logFilePath != liveConfiguration->logFilePath;
     if (needsUpdate) {
         if (logFile) delete logFile;

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -121,8 +121,10 @@ void Profiler::setSamplingInterval(int intervalMin, int intervalMax) {
         logError("WARN: Unable to modify running profiler\n");
         return;
     }
-    liveConfiguration->samplingIntervalMin = intervalMin;
-    liveConfiguration->samplingIntervalMax = intervalMax;
+    int min = intervalMin > 0 ? intervalMin : DEFAULT_SAMPLING_INTERVAL;
+    int max = intervalMax > 0 ? intervalMax : DEFAULT_SAMPLING_INTERVAL;
+    liveConfiguration->samplingIntervalMin = std::min(min, max);
+    liveConfiguration->samplingIntervalMax = std::max(min, max);
     reloadConfig = true;
 }
 
@@ -131,7 +133,9 @@ void Profiler::setMaxFramesToCapture(int maxFramesToCapture) {
         logError("WARN: Unable to modify running profiler\n");
         return;
     }
-    liveConfiguration->maxFramesToCapture = maxFramesToCapture;
+    int res = (maxFramesToCapture > 0 && maxFramesToCapture < MAX_FRAMES_TO_CAPTURE) ? 
+        maxFramesToCapture : DEFAULT_MAX_FRAMES_TO_CAPTURE;
+    liveConfiguration->maxFramesToCapture = res;
     reloadConfig = true;
 }
 

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -153,7 +153,6 @@ void Profiler::configure() {
         string fileNameStr;
         if (fileName == NULL) {
             ostringstream fileBuilder;
-            long pid = (long) getpid();
             long epochMillis = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
             fileBuilder << "log-" << pid << "-" << epochMillis << ".hpl";
             fileNameStr = fileBuilder.str();

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -107,10 +107,10 @@ void Profiler::setFilePath(char *newFilePath) {
         logError("WARN: Unable to modify running profiler\n");
         return;
     }
-    
+
     if (liveConfiguration->logFilePath && 
         liveConfiguration->logFilePath != configuration_->logFilePath)
-        delete liveConfiguration->logFilePath;
+        safe_free_string(liveConfiguration->logFilePath);
 
     liveConfiguration->logFilePath = newFilePath;
     reloadConfig = true;
@@ -143,7 +143,7 @@ void Profiler::configure() {
         if (logFile) delete logFile;
         if (writer) delete writer;
         if (configuration_->logFilePath)
-            delete configuration_->logFilePath;
+            safe_free_string(configuration_->logFilePath);
         
         char *fileName = liveConfiguration->logFilePath;
         string fileNameStr;

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -27,6 +27,7 @@ public:
         // main object graph instantiated here
         // these objects all live for the lifecycle of the program
         liveConfiguration = new ConfigurationOptions(*configuration);
+        configure();
     }
 
     bool start(JNIEnv *jniEnv);
@@ -65,8 +66,6 @@ public:
     }
 
 private:
-    void configure();
-
     JavaVM *jvm_;
 
     jvmtiEnv *jvmti_;
@@ -91,7 +90,7 @@ private:
             jvmtiEnv *jvmti,
             MethodListener &logWriter);
 
-    static string generateFileName();
+    void configure();
 
     DISALLOW_COPY_AND_ASSIGN(Profiler);
 };

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -27,6 +27,7 @@ public:
         // main object graph instantiated here
         // these objects all live for the lifecycle of the program
         configuration_ = new ConfigurationOptions();
+        pid = (long) getpid();
 
         // explicitly call setters to validate input params
         setSamplingInterval(liveConfiguration->samplingIntervalMin, 
@@ -92,6 +93,8 @@ private:
     SignalHandler* handler_;
 
     bool reloadConfig;
+
+    long pid;
 
     static bool lookupFrameInformation(const JVMPI_CallFrame &frame,
             jvmtiEnv *jvmti,

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -40,7 +40,7 @@ public:
 
     /* Several getters and setters for externals APIs */
 
-    char* getFilePath() const { return liveConfiguration->logFilePath; }
+    char *getFilePath() const { return liveConfiguration->logFilePath; }
 
     int getSamplingIntervalMin() const { return liveConfiguration->samplingIntervalMin; }
 

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -35,35 +35,6 @@ const int kTraceProfilerStopOk = 9;
 
 TRACE_DECLARE(Profiler, kTraceProfilerTotal);
 
-#ifdef TEST_PROFILER
-
-const int kTraceProcMockTotal = 5;
-
-const int kTraceProcMockStart = 0;
-const int kTraceProcMockStop = 1;
-const int kTraceProcMockRunning = 2;
-const int kTraceProcMockConstructor = 3;
-const int kTraceProcMockDestructor = 4;
-
-TRACE_DECLARE(ProcessorMock, kTraceProcMockTotal);
-
-class ProcessorMock {
-private:
-    std::atomic<bool> running;
-
-public:
-    ProcessorMock();
-
-    ~ProcessorMock();
-
-    void start();
-
-    void stop();
-
-    bool isRunning() const;
-};
-
-#endif
 
 class Profiler {
 public:
@@ -76,9 +47,6 @@ public:
         configuration_ = new ConfigurationOptions();
         pid = (long) getpid();
 
-#ifdef TEST_PROFILER
-        processorMock = NULL;
-#endif
         // explicitly call setters to validate input params
         setSamplingInterval(liveConfiguration->samplingIntervalMin, 
             liveConfiguration->samplingIntervalMax);
@@ -88,10 +56,6 @@ public:
     }
 
     bool start(JNIEnv *jniEnv);
-
-#ifdef TEST_PROFILER
-    bool start();
-#endif
 
     void stop();
 
@@ -118,10 +82,6 @@ public:
     ~Profiler();
 
 private:
-#ifdef TEST_PROFILER
-    friend class ProfilerTestHelper;
-#endif
-
     JavaVM *jvm_;
 
     jvmtiEnv *jvmti_;
@@ -137,10 +97,6 @@ private:
     CircularQueue *buffer;
 
     Processor *processor;
-
-#ifdef TEST_PROFILER
-    ProcessorMock *processorMock;
-#endif
 
     SignalHandler* handler_;
 
@@ -161,21 +117,5 @@ private:
 
     DISALLOW_COPY_AND_ASSIGN(Profiler);
 };
-
-#ifdef TEST_PROFILER
-
-class ProfilerTestHelper {
-private:
-    Profiler *prof;
-
-public:
-    ProfilerTestHelper(Profiler *p) : prof(p) {}
-
-    ConfigurationOptions *getHiddenConfig() {
-        return prof->configuration_;
-    }
-}; 
-
-#endif
 
 #endif // PROFILER_H

--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -27,6 +27,12 @@ public:
         // main object graph instantiated here
         // these objects all live for the lifecycle of the program
         configuration_ = new ConfigurationOptions();
+
+        // explicitly call setters to validate input params
+        setSamplingInterval(liveConfiguration->samplingIntervalMin, 
+            liveConfiguration->samplingIntervalMax);
+        setMaxFramesToCapture(liveConfiguration->maxFramesToCapture);
+        
         configure();
     }
 

--- a/src/main/cpp/trace.h
+++ b/src/main/cpp/trace.h
@@ -1,0 +1,66 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+/** Simple tracing framework ported from @preshing's Turf Trace_Counters
+ *  URL: https://github.com/preshing/turf
+ */
+
+class TraceGroup {
+public:
+    struct Counter {
+        std::atomic<int> count;
+        const char* str;
+
+        Counter(int i, const char* d) : count(i), str(d) {
+        }
+
+        Counter(const Counter &cnt) : count(cnt.count.load()), str(cnt.str) {
+        }
+    };
+
+private:
+    const char* m_name;
+    Counter* m_counters;
+    int m_numCounters;
+
+public:
+    TraceGroup(const char* name, Counter* counters, int numCounters)
+        : m_name(name), m_counters(counters), m_numCounters(numCounters) {
+    }
+
+    void dump() {
+    	printf("--------------- %s\n", m_name);
+    	for (int i = 0; i < m_numCounters; i++) {
+        	printf("#### %s: %d\n", m_counters[i].str, m_counters[i].count.load(std::memory_order_relaxed));
+    	}
+    }
+
+    void dumpIfUsed() {
+		for (int i = 0; i < m_numCounters; i++) {
+        	if (m_counters[i].count.load(std::memory_order_relaxed)) {
+            	dump();
+            	break;
+        	}
+    	}
+    }
+
+    void reset() {
+        for (int i = 0; i < m_numCounters; i++) {
+            m_counters[i].count.store(0, std::memory_order_relaxed);
+        }
+    }
+};
+
+#define TRACE_DECLARE(group, count)      extern TraceGroup::Counter Trace_##group[count]; extern TraceGroup TraceGroup_##group;
+#define TRACE_DEFINE_BEGIN(group, count) TraceGroup::Counter Trace_##group[count] = {
+#define TRACE_DEFINE(desc)                   TraceGroup::Counter(0, desc),
+#define TRACE_DEFINE_END(group, count)   }; \
+                                         TraceGroup TraceGroup_##group(#group, Trace_##group, count);
+
+#ifndef ENABLE_TRACING
+	#define TRACE(group, index) 	     do {} while(0)
+#else
+	#define TRACE(group, index) 	     Trace_##group[index].count.fetch_add(1, std::memory_order_relaxed)
+#endif
+
+#endif

--- a/src/main/java/AgentApiExample.java
+++ b/src/main/java/AgentApiExample.java
@@ -1,0 +1,81 @@
+import com.insightfullogic.honest_profiler.core.control.Agent;
+
+/**
+ * Copyright (c) 2014 Richard Warburton (richard.warburton@gmail.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ **/
+public class AgentApiExample
+{
+
+    public static void main(String[] args) throws Exception
+    {
+        final String fileNameInit = "/tmp/log-1.hpl";
+        final String fileNameUpd = "/tmp/log-2.hpl";
+        final int samplingIntervalInit = 41;
+        final int samplingIntervalUpd = 333;
+        final int maxFramesToCaptureInit = 42;
+        final int maxFramesToCaptureUpd = 121;
+
+        Agent.setFilePath(fileNameInit);
+        assertEquals(fileNameInit, Agent.getFilePath(), "set initial logs file path");
+            
+        Agent.setSamplingInterval(samplingIntervalInit, 2 * samplingIntervalInit);
+        assertEquals(samplingIntervalInit, Agent.getSamplingIntervalMin(), "set initial min sampling interval");
+        assertEquals(2 * samplingIntervalInit, Agent.getSamplingIntervalMax(), "set initial max sampling interval");
+            
+        Agent.setMaxFramesToCapture(maxFramesToCaptureInit);
+        assertEquals(maxFramesToCaptureInit, Agent.getMaxFramesToCapture(), "set initial max stack frames to capture");
+
+        Agent.start();
+
+        Agent.setFilePath(fileNameUpd);
+        assertEquals(fileNameInit, Agent.getFilePath(), "update logs file path when profiler is running");
+            
+        Agent.setSamplingInterval(samplingIntervalUpd, 2 * samplingIntervalUpd);
+        assertEquals(samplingIntervalInit, Agent.getSamplingIntervalMin(), "update min sampling interval when profiler is running");
+        assertEquals(2 * samplingIntervalInit, Agent.getSamplingIntervalMax(), "update max sampling interval when profiler is running");
+            
+        Agent.setMaxFramesToCapture(maxFramesToCaptureUpd);
+        assertEquals(maxFramesToCaptureInit, Agent.getMaxFramesToCapture(), "update max stack frames to capture when profiler is running");
+
+        Agent.stop();
+
+        Agent.setFilePath(fileNameUpd);
+        assertEquals(fileNameUpd, Agent.getFilePath(), "update logs file path");
+            
+        Agent.setSamplingInterval(samplingIntervalUpd, 2 * samplingIntervalUpd);
+        assertEquals(samplingIntervalUpd, Agent.getSamplingIntervalMin(), "update min sampling interval");
+        assertEquals(2 * samplingIntervalUpd, Agent.getSamplingIntervalMax(), "update max sampling interval");
+            
+        Agent.setMaxFramesToCapture(maxFramesToCaptureUpd);
+        assertEquals(maxFramesToCaptureUpd, Agent.getMaxFramesToCapture(), "update max stack frames to capture");
+    }
+
+    private static void assertEquals(Object expected, Object actual, String description) 
+    {
+        if (!expected.equals(actual)) 
+        {
+            throw new RuntimeException(
+                String.format("Assertion failed for '%s'. Expected '%s', actual '%s'", 
+                    description, expected.toString(), actual.toString())
+            );
+        }
+    }
+}

--- a/src/main/java/com/insightfullogic/honest_profiler/core/control/Agent.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/control/Agent.java
@@ -28,4 +28,18 @@ public class Agent
     public static synchronized native void stop();
 
     public static synchronized native boolean isRunning();
+
+    public static synchronized native int getSamplingIntervalMin();
+
+    public static synchronized native int getSamplingIntervalMax();
+
+    public static synchronized native int getMaxFramesToCapture();
+
+    public static synchronized native String getFilePath();
+
+    public static synchronized native void setFilePath(String filePath);
+
+    public static synchronized native void setSamplingInterval(int intervalMin, int intervalMax);
+
+    public static synchronized native void setFilePath(int maxFramesToCapture);
 }

--- a/src/main/java/com/insightfullogic/honest_profiler/core/control/Agent.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/control/Agent.java
@@ -23,23 +23,23 @@ package com.insightfullogic.honest_profiler.core.control;
 
 public class Agent
 {
-    public static synchronized native boolean start();
+    public static native boolean start();
 
-    public static synchronized native void stop();
+    public static native void stop();
 
-    public static synchronized native boolean isRunning();
+    public static native boolean isRunning();
 
-    public static synchronized native int getSamplingIntervalMin();
+    public static native int getSamplingIntervalMin();
 
-    public static synchronized native int getSamplingIntervalMax();
+    public static native int getSamplingIntervalMax();
 
-    public static synchronized native int getMaxFramesToCapture();
+    public static native int getMaxFramesToCapture();
 
-    public static synchronized native String getFilePath();
+    public static native String getFilePath();
 
-    public static synchronized native void setFilePath(String filePath);
+    public static native void setFilePath(String filePath);
 
-    public static synchronized native void setSamplingInterval(int intervalMin, int intervalMax);
+    public static native void setSamplingInterval(int intervalMin, int intervalMax);
 
-    public static synchronized native void setMaxFramesToCapture(int maxFramesToCapture);
+    public static native void setMaxFramesToCapture(int maxFramesToCapture);
 }

--- a/src/main/java/com/insightfullogic/honest_profiler/core/control/Agent.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/control/Agent.java
@@ -41,5 +41,5 @@ public class Agent
 
     public static synchronized native void setSamplingInterval(int intervalMin, int intervalMax);
 
-    public static synchronized native void setFilePath(int maxFramesToCapture);
+    public static synchronized native void setMaxFramesToCapture(int maxFramesToCapture);
 }

--- a/src/test/cpp/test_profiler_config.cpp
+++ b/src/test/cpp/test_profiler_config.cpp
@@ -4,40 +4,83 @@
 #include "test.h"
 #include "../../main/cpp/profiler.h"
 
+static JavaVM *jvm = NULL;
+static JNIEnv *env = NULL;
+static jvmtiEnv *jvmti = NULL;
+
+static void init() {
+	if (jvm) return;
+
+	int res;
+	JavaVMInitArgs vm_args;
+    vm_args.version = JNI_VERSION_1_6;
+    vm_args.nOptions = 0;
+    vm_args.options = NULL;
+    vm_args.ignoreUnrecognized = false;
+    
+    res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
+    if (res < 0 || !env) {
+    	std::cerr << "Can't create a VM instance (err: " << res << ")\n";
+    	return;
+    }
+
+    res = jvm->GetEnv((void**)&jvmti, JVMTI_VERSION);
+    if (res != JNI_OK) {
+    	std::cerr << "Can't get a jvmti (err: " << res << ")\n";
+    	return;
+    }
+}
+
 class ProfilerControl {
 public:
-  Profiler *profiler;
-  ProfilerTestHelper *helper;
-  ConfigurationOptions *liveConfig;
-  ConfigurationOptions *currentConfig;
+	Profiler *profiler;
+	ConfigurationOptions *liveConfig;
 
 public:
-  ProfilerControl() {
-    liveConfig = new ConfigurationOptions();
-    profiler = new Profiler(NULL, NULL, liveConfig);
-    helper = new ProfilerTestHelper(profiler);
-    currentConfig = helper->getHiddenConfig();
-  }
+	ProfilerControl() {
+		init();
+		liveConfig = new ConfigurationOptions();
+		profiler = new Profiler(jvm, jvmti, liveConfig);
 
-  ~ProfilerControl() {
-    delete helper;
-    delete profiler;
-    delete liveConfig;
-  }
+		// otherwise Profiler::handle called from bootstrapHandle in agent.cpp will fail
+		setProfiler(profiler);
+		Asgct::SetAsgct(Accessors::GetJvmFunction<ASGCTType>("AsyncGetCallTrace"));
+	}
+
+	~ProfilerControl() {
+		delete profiler;
+		delete liveConfig;
+	}
 };
+
+static void threadStartFunction(Profiler *p) {
+	JNIEnv *currEnv;
+
+	int res = jvm->AttachCurrentThread((void**)&currEnv, NULL);
+	if (res < 0 || currEnv == NULL) {
+		std::cerr << "Can't create JNI instance (err: " << res << ")\n";
+    	return;
+	}
+
+	p->start(currEnv);
+	jvm->DetachCurrentThread();	
+}
+
+
+static void threadStopFunction(Profiler *p) {
+	// no need to attach to VM
+	p->stop();
+}
 
 TEST_FIXTURE(ProfilerControl, ProfilerInitialization) {
 	CHECK(profiler);
 	CHECK(!profiler->isRunning());
-	CHECK(helper);
 	CHECK(liveConfig);
-	CHECK(currentConfig);
 
-	// check that content in configs is the same
-	CHECK_EQUAL(liveConfig->samplingIntervalMin, currentConfig->samplingIntervalMin);
-	CHECK_EQUAL(liveConfig->samplingIntervalMax, currentConfig->samplingIntervalMax);
-	CHECK_EQUAL(liveConfig->logFilePath, currentConfig->logFilePath);
-	CHECK_EQUAL(liveConfig->maxFramesToCapture, currentConfig->maxFramesToCapture);
+	CHECK_EQUAL(liveConfig->samplingIntervalMin, profiler->getSamplingIntervalMin());
+	CHECK_EQUAL(liveConfig->samplingIntervalMax, profiler->getSamplingIntervalMax());
+	CHECK_EQUAL(liveConfig->maxFramesToCapture, profiler->getMaxFramesToCapture());
+	CHECK_EQUAL(std::string(liveConfig->logFilePath), profiler->getFilePath());
 }
 
 TEST_FIXTURE(ProfilerControl, ProfilerChangeSettings) {
@@ -59,39 +102,36 @@ TEST_FIXTURE(ProfilerControl, ProfilerChangeSettings) {
 	CHECK_EQUAL(newMaxFramesToCapture, profiler->getMaxFramesToCapture());
 	CHECK_EQUAL(std::string(newFilePath1), profiler->getFilePath());
 
-	// check that content in configs is defferent
-	CHECK(currentConfig->samplingIntervalMin != profiler->getSamplingIntervalMin());
-	CHECK(currentConfig->samplingIntervalMax != profiler->getSamplingIntervalMax());
-	CHECK(currentConfig->maxFramesToCapture != profiler->getMaxFramesToCapture());
-	CHECK(std::string(currentConfig->logFilePath) != profiler->getFilePath());
+#ifdef ENABLE_TRACING
+	int prev = Trace_Processor[kTraceProcessorStart].count.load();
+#endif
 
-	int prev = Trace_ProcessorMock[kTraceProcMockStart].count.load();
 	// start profiler
-	CHECK(profiler->start());
+	CHECK(profiler->start(env));
 	CHECK(profiler->isRunning());
-	CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStart].count.load());
+
+#ifdef ENABLE_TRACING
+	CHECK_EQUAL(prev + 1, Trace_Processor[kTraceProcessorStart].count.load());
+#endif
 
 	// start it once again
-	CHECK(profiler->start());
-	CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStart].count.load());
+	CHECK(profiler->start(env));
 
-	// check that content was syncronized in configs
-	CHECK_EQUAL(liveConfig->samplingIntervalMin, currentConfig->samplingIntervalMin);
-	CHECK_EQUAL(liveConfig->samplingIntervalMax, currentConfig->samplingIntervalMax);
-	CHECK_EQUAL(liveConfig->logFilePath, currentConfig->logFilePath);
-	CHECK_EQUAL(liveConfig->maxFramesToCapture, currentConfig->maxFramesToCapture);
+#ifdef ENABLE_TRACING
+	CHECK_EQUAL(prev + 1, Trace_Processor[kTraceProcessorStart].count.load());
+#endif
 
-	// check that content is correct
-	CHECK_EQUAL(newSamplingIntervalMin, currentConfig->samplingIntervalMin);
-	CHECK_EQUAL(newSamplingIntervalMax, currentConfig->samplingIntervalMax);
-	CHECK_EQUAL(newMaxFramesToCapture, currentConfig->maxFramesToCapture);
-	CHECK_EQUAL(newFilePath1, currentConfig->logFilePath);
+	// check that getters return correct new values
+	CHECK_EQUAL(newSamplingIntervalMin, profiler->getSamplingIntervalMin());
+	CHECK_EQUAL(newSamplingIntervalMax, profiler->getSamplingIntervalMax());
+	CHECK_EQUAL(newMaxFramesToCapture, profiler->getMaxFramesToCapture());
+	CHECK_EQUAL(std::string(newFilePath1), profiler->getFilePath());
 
 	// no changes allowed when profiler is running
 	profiler->setFilePath(newFilePath2);
 	CHECK_EQUAL(std::string(newFilePath1), profiler->getFilePath());
 
-	// check that memory is freed in live config
+	// set 2 values in a row (valgrind: check that memory is reclaimed)
 	profiler->stop();
 	profiler->setFilePath(newFilePath2);
 	profiler->setFilePath(NULL);
@@ -100,8 +140,7 @@ TEST_FIXTURE(ProfilerControl, ProfilerChangeSettings) {
 	profiler->setMaxFramesToCapture(-100);
 
 	// check that memory is freed in hidden config
-	profiler->start();
-	CHECK((char*)NULL != currentConfig->logFilePath);
+	profiler->start(env);
 	CHECK(std::string() != profiler->getFilePath());
 	CHECK(profiler->getMaxFramesToCapture() > 0);
 
@@ -109,34 +148,36 @@ TEST_FIXTURE(ProfilerControl, ProfilerChangeSettings) {
 }
 
 TEST_FIXTURE(ProfilerControl, ProfilerConcurrentStartStop) {
-	bool (Profiler::*foo)(void) = &Profiler::start;
-	const int tsize = 4;
+	const int tsize = 1;
 	std::vector<std::thread> threads(tsize);
 
 	for (int it = 0; it < 100; it++) {
-		int prev = Trace_ProcessorMock[kTraceProcMockStart].count.load();
+		int prev = Trace_Processor[kTraceProcessorStart].count.load();
 		for (int i = 0; i < tsize; i++)
-			threads[i] = std::thread(foo, std::ref(profiler));
+			threads[i] = std::thread(&threadStartFunction, std::ref(profiler));
 		for (int i = 0; i < tsize; i++)
 			threads[i].join();
 
+#ifdef ENABLE_TRACING
 		// only 1 will succeed
-		CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStart].count.load());
+		CHECK_EQUAL(prev + 1, Trace_Processor[kTraceProcessorStart].count.load());
+#endif
 		CHECK(profiler->isRunning());
 
-		prev = Trace_ProcessorMock[kTraceProcMockStop].count.load();
+		prev = Trace_Processor[kTraceProcessorStop].count.load();
 		for (int i = 0; i < tsize; i++)
-			threads[i] = std::thread(&Profiler::stop, std::ref(profiler));
+			threads[i] = std::thread(&threadStopFunction, std::ref(profiler));
 		for (int i = 0; i < tsize; i++)
 			threads[i].join();
 
-		CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStop].count.load());
+#ifdef ENABLE_TRACING
+		CHECK_EQUAL(prev + 1, Trace_Processor[kTraceProcessorStop].count.load());
+#endif
 		CHECK(!profiler->isRunning());
 	}
 }
 
 TEST_FIXTURE(ProfilerControl, ProfilerConcurrentModification) {
-	bool (Profiler::*startFoo)(void) = &Profiler::start;
 	void (Profiler::*setFoo)(int) = &Profiler::setMaxFramesToCapture;
 	const int tsize = 4;
 	int totals[tsize + 1] = {0};
@@ -148,7 +189,7 @@ TEST_FIXTURE(ProfilerControl, ProfilerConcurrentModification) {
 		for (int i = 0; i < tsize; i++) {
 			threads[i] = std::thread(setFoo, std::ref(profiler), i + 1);
 		}
-		std::thread starter(startFoo, std::ref(profiler));
+		std::thread starter(&threadStartFunction, std::ref(profiler));
 		for (int i = 0; i < tsize; i++)
 			threads[i].join();
 		starter.join();
@@ -167,6 +208,8 @@ TEST_FIXTURE(ProfilerControl, ProfilerConcurrentModification) {
 	}
 	CHECK(check >= p50);
 
+#ifdef ENABLE_TRACING
 	//std::cout << "#### Concurrent modification tracing results:\n";
 	//TraceGroup_Profiler.dumpIfUsed();
+#endif
 }

--- a/src/test/cpp/test_profiler_config.cpp
+++ b/src/test/cpp/test_profiler_config.cpp
@@ -1,0 +1,172 @@
+#include <thread>
+#include <vector>
+#include <iostream>
+#include "test.h"
+#include "../../main/cpp/profiler.h"
+
+class ProfilerControl {
+public:
+  Profiler *profiler;
+  ProfilerTestHelper *helper;
+  ConfigurationOptions *liveConfig;
+  ConfigurationOptions *currentConfig;
+
+public:
+  ProfilerControl() {
+    liveConfig = new ConfigurationOptions();
+    profiler = new Profiler(NULL, NULL, liveConfig);
+    helper = new ProfilerTestHelper(profiler);
+    currentConfig = helper->getHiddenConfig();
+  }
+
+  ~ProfilerControl() {
+    delete helper;
+    delete profiler;
+    delete liveConfig;
+  }
+};
+
+TEST_FIXTURE(ProfilerControl, ProfilerInitialization) {
+	CHECK(profiler);
+	CHECK(!profiler->isRunning());
+	CHECK(helper);
+	CHECK(liveConfig);
+	CHECK(currentConfig);
+
+	// check that content in configs is the same
+	CHECK_EQUAL(liveConfig->samplingIntervalMin, currentConfig->samplingIntervalMin);
+	CHECK_EQUAL(liveConfig->samplingIntervalMax, currentConfig->samplingIntervalMax);
+	CHECK_EQUAL(liveConfig->logFilePath, currentConfig->logFilePath);
+	CHECK_EQUAL(liveConfig->maxFramesToCapture, currentConfig->maxFramesToCapture);
+}
+
+TEST_FIXTURE(ProfilerControl, ProfilerChangeSettings) {
+	int newSamplingIntervalMin = 13;
+	int newSamplingIntervalMax = 17;
+	int newMaxFramesToCapture = 225;
+	char *newFilePath1 = (char*)"/dev/null";
+	char *newFilePath2 = (char*)"/dev/sda";
+
+	// modify settings
+	CHECK(!profiler->isRunning());
+	profiler->setSamplingInterval(newSamplingIntervalMin, newSamplingIntervalMax);
+	profiler->setMaxFramesToCapture(newMaxFramesToCapture);
+	profiler->setFilePath(newFilePath1);
+
+	// check that getters return correct new values
+	CHECK_EQUAL(newSamplingIntervalMin, profiler->getSamplingIntervalMin());
+	CHECK_EQUAL(newSamplingIntervalMax, profiler->getSamplingIntervalMax());
+	CHECK_EQUAL(newMaxFramesToCapture, profiler->getMaxFramesToCapture());
+	CHECK_EQUAL(std::string(newFilePath1), profiler->getFilePath());
+
+	// check that content in configs is defferent
+	CHECK(currentConfig->samplingIntervalMin != profiler->getSamplingIntervalMin());
+	CHECK(currentConfig->samplingIntervalMax != profiler->getSamplingIntervalMax());
+	CHECK(currentConfig->maxFramesToCapture != profiler->getMaxFramesToCapture());
+	CHECK(std::string(currentConfig->logFilePath) != profiler->getFilePath());
+
+	int prev = Trace_ProcessorMock[kTraceProcMockStart].count.load();
+	// start profiler
+	CHECK(profiler->start());
+	CHECK(profiler->isRunning());
+	CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStart].count.load());
+
+	// start it once again
+	CHECK(profiler->start());
+	CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStart].count.load());
+
+	// check that content was syncronized in configs
+	CHECK_EQUAL(liveConfig->samplingIntervalMin, currentConfig->samplingIntervalMin);
+	CHECK_EQUAL(liveConfig->samplingIntervalMax, currentConfig->samplingIntervalMax);
+	CHECK_EQUAL(liveConfig->logFilePath, currentConfig->logFilePath);
+	CHECK_EQUAL(liveConfig->maxFramesToCapture, currentConfig->maxFramesToCapture);
+
+	// check that content is correct
+	CHECK_EQUAL(newSamplingIntervalMin, currentConfig->samplingIntervalMin);
+	CHECK_EQUAL(newSamplingIntervalMax, currentConfig->samplingIntervalMax);
+	CHECK_EQUAL(newMaxFramesToCapture, currentConfig->maxFramesToCapture);
+	CHECK_EQUAL(newFilePath1, currentConfig->logFilePath);
+
+	// no changes allowed when profiler is running
+	profiler->setFilePath(newFilePath2);
+	CHECK_EQUAL(std::string(newFilePath1), profiler->getFilePath());
+
+	// check that memory is freed in live config
+	profiler->stop();
+	profiler->setFilePath(newFilePath2);
+	profiler->setFilePath(NULL);
+
+	// set bad input 
+	profiler->setMaxFramesToCapture(-100);
+
+	// check that memory is freed in hidden config
+	profiler->start();
+	CHECK((char*)NULL != currentConfig->logFilePath);
+	CHECK(std::string() != profiler->getFilePath());
+	CHECK(profiler->getMaxFramesToCapture() > 0);
+
+	profiler->stop();
+}
+
+TEST_FIXTURE(ProfilerControl, ProfilerConcurrentStartStop) {
+	bool (Profiler::*foo)(void) = &Profiler::start;
+	const int tsize = 4;
+	std::vector<std::thread> threads(tsize);
+
+	for (int it = 0; it < 100; it++) {
+		int prev = Trace_ProcessorMock[kTraceProcMockStart].count.load();
+		for (int i = 0; i < tsize; i++)
+			threads[i] = std::thread(foo, std::ref(profiler));
+		for (int i = 0; i < tsize; i++)
+			threads[i].join();
+
+		// only 1 will succeed
+		CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStart].count.load());
+		CHECK(profiler->isRunning());
+
+		prev = Trace_ProcessorMock[kTraceProcMockStop].count.load();
+		for (int i = 0; i < tsize; i++)
+			threads[i] = std::thread(&Profiler::stop, std::ref(profiler));
+		for (int i = 0; i < tsize; i++)
+			threads[i].join();
+
+		CHECK_EQUAL(prev + 1, Trace_ProcessorMock[kTraceProcMockStop].count.load());
+		CHECK(!profiler->isRunning());
+	}
+}
+
+TEST_FIXTURE(ProfilerControl, ProfilerConcurrentModification) {
+	bool (Profiler::*startFoo)(void) = &Profiler::start;
+	void (Profiler::*setFoo)(int) = &Profiler::setMaxFramesToCapture;
+	const int tsize = 4;
+	int totals[tsize + 1] = {0};
+	std::vector<std::thread> threads(tsize);
+	TraceGroup_Profiler.reset();
+
+	for (int it = 0; it < 100; it++) {
+		profiler->setMaxFramesToCapture(tsize + 1);
+		for (int i = 0; i < tsize; i++) {
+			threads[i] = std::thread(setFoo, std::ref(profiler), i + 1);
+		}
+		std::thread starter(startFoo, std::ref(profiler));
+		for (int i = 0; i < tsize; i++)
+			threads[i].join();
+		starter.join();
+		
+		int val = profiler->getMaxFramesToCapture();
+		CHECK(0 < val && val < tsize + 2);
+		totals[val - 1]++;
+
+		profiler->stop();
+	}
+
+	int p50 = (tsize + 1) >> 1; // at least 50% should be != 0
+	int check = 0;
+	for (int i = 0; i < tsize + 1; i++) {
+		check += (totals[i] != 0);
+	}
+	CHECK(check >= p50);
+
+	//std::cout << "#### Concurrent modification tracing results:\n";
+	//TraceGroup_Profiler.dumpIfUsed();
+}

--- a/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
@@ -95,11 +95,7 @@ public class AgentIntegrationTest
 
                     runner.startProfiler();
                     
-                    parkNanos(SECONDS.toNanos(2));
-                    
                     seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
-                    
-                    parkNanos(SECONDS.toNanos(2));
                     
                     runner.stopProfiler();
 

--- a/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/system_tests/AgentIntegrationTest.java
@@ -28,6 +28,7 @@ import com.insightfullogic.honest_profiler.core.sources.VirtualMachine;
 import com.insightfullogic.honest_profiler.ports.sources.FileLogSource;
 import com.insightfullogic.honest_profiler.ports.sources.LocalMachineSource;
 import com.insightfullogic.honest_profiler.testing_utilities.AgentRunner;
+import com.insightfullogic.honest_profiler.testing_utilities.NonInteractiveAgentRunner;
 import com.insightfullogic.lambdabehave.JunitSuiteRunner;
 import com.insightfullogic.lambdabehave.expectations.Expect;
 import org.hamcrest.Matcher;
@@ -91,19 +92,35 @@ public class AgentIntegrationTest
                     AtomicReference<Profile> lastProfile = discoverVirtualMachines();
 
                     seenTraceCount = expectNonIncreasingTraceCount(expect, seenTraceCount, lastProfile);
-                    runner.startProfiler();
 
+                    runner.startProfiler();
+                    
+                    parkNanos(SECONDS.toNanos(2));
+                    
                     seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
+                    
+                    parkNanos(SECONDS.toNanos(2));
+                    
                     runner.stopProfiler();
 
                     seenTraceCount = expectIncreasingTraceCount(expect, seenTraceCount, lastProfile);
                     seenTraceCount = expectNonIncreasingTraceCount(expect, seenTraceCount, lastProfile);
                 });
             });
+
+            it.should("should be able to change agent settings", expect ->
+            {
+                NonInteractiveAgentRunner.run("AgentApiExample", "start=0", runner ->
+                {
+                    expect.that(runner.isSuccessful()).is(equalTo(true));
+
+                    if (!runner.isSuccessful())
+                        logger.debug("Errors in agent profiled process {}", runner.getErrorMessages());
+                });
+            });
         });
 
     }
-
 
     private AtomicReference<Profile> discoverVirtualMachines()
     {

--- a/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/NonInteractiveAgentRunner.java
+++ b/src/test/java/com/insightfullogic/honest_profiler/testing_utilities/NonInteractiveAgentRunner.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2014 Richard Warburton (richard.warburton@gmail.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ **/
+package com.insightfullogic.honest_profiler.testing_utilities;
+
+import com.insightfullogic.honest_profiler.core.platform.Platforms;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.function.Consumer;
+
+
+public class NonInteractiveAgentRunner
+{
+    private static final Logger logger = LoggerFactory.getLogger(NonInteractiveAgentRunner.class);
+
+    private final String className;
+    private final String args;
+
+    private String errorMessage;
+    private boolean isSuccessful;
+
+    private NonInteractiveAgentRunner(final String className, final String args)
+    {
+        this.className = className;
+        this.args = args;
+        isSuccessful = true;
+    }
+
+    public static void run(final String className, final Consumer<NonInteractiveAgentRunner> handler) throws IOException
+    {
+        run(className, (String) null, handler);
+    }
+
+    public static void run(final String className,
+                           final String[] args,
+                           final Consumer<NonInteractiveAgentRunner> handler) throws IOException
+    {
+        run(className, String.join(",", args), handler);
+    }
+
+    public static void run(final String className,
+                           final String args,
+                           final Consumer<NonInteractiveAgentRunner> handler) throws IOException
+    {
+        NonInteractiveAgentRunner runner = new NonInteractiveAgentRunner(className, args);
+        runner.startProcess();
+        handler.accept(runner);
+    }
+
+    private void startProcess() throws IOException
+    {
+        String java = System.getProperty("java.home") + "/bin/java";
+        String agentArg = "-agentpath:build/liblagent" + Platforms.getDynamicLibraryExtension() + (args != null ? "=" + args : "");
+        // Eg: java -agentpath:build/liblagent.so -cp target/classes/ AgentApiExample
+        Process process = new ProcessBuilder()
+            .command(java, agentArg, "-cp", "target/classes/", className)
+            .redirectErrorStream(true)
+            .start();
+
+        StringBuilder outputBuffer = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream())))
+        {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (isSuccessful && line.contains("Exception in thread")) 
+                    isSuccessful = false;
+                outputBuffer.append(line).append('\n');
+            }
+        }
+        errorMessage = outputBuffer.toString();
+    }
+
+    public boolean isSuccessful() 
+    {
+        return isSuccessful;
+    }
+
+    public String getErrorMessages() {
+        return errorMessage;
+    }
+}


### PR DESCRIPTION
Hi Richard,

This PR adds getters and setters to Profiler class, so that profiler instance can be configured at runtime via Java (Agent interface) and TCP socket interface (get/set commands). Profiler internally validates all input and frees allocated memory when some data (strings) goes out of the scope. Only **Profiler** specific params can be changed at this moment:
- sampling interval
- max frames to capture
- output file path

I realize that it introduces a lot of changes, but it doesn't break any existing Agent functionality.