### PR TITLE
Set hard limit for maxFrames to 2048

### DIFF
--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -16,7 +16,7 @@ Profiler *getProfiler();
 
 const int DEFAULT_SAMPLING_INTERVAL = 1;
 const int DEFAULT_MAX_FRAMES_TO_CAPTURE = 128;
-const int MAX_FRAMES_TO_CAPTURE = 512;
+const int MAX_FRAMES_TO_CAPTURE = 2048;
 
 #if defined(STATIC_ALLOCATION_ALLOCA)
   #define STATIC_ARRAY(NAME, TYPE, SIZE, MAXSZ) TYPE *NAME = (TYPE*)alloca((SIZE) * sizeof(TYPE))


### PR DESCRIPTION
The current hard upper limit for `maxFrames` is `512`. That's too low for my use cases. Set the hard limit to `2048`.