### PR TITLE
Java tests fail when default Locale is not 'en'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-surefire-plugin</artifactId>
+			    <version>2.19.1</version>
+			    <configuration>
+			    	<argLine>-Duser.country=US -Duser.language=en</argLine>
+			    </configuration>
+			</plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
Force locale in the maven-surefire plugin

Fixes #162