### PR TITLE
Remove usage of thread_local variable to support XCode

### DIFF
--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -209,7 +209,6 @@ void JNICALL OnThreadStart(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread)
 void JNICALL OnThreadEnd(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread) {
     pthread_sigmask(SIG_BLOCK, &prof_signal_mask, NULL);
     threadMap.remove(jni_env);
-    threadMap.detach(); // detach must be called
 }
 
 static bool RegisterJvmti(jvmtiEnv *jvmti) {

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -200,8 +200,7 @@ void JNICALL OnThreadStart(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread)
                 }
             }
         }
-        // no need to call attach explicitly
-        threadMap.put(jni_env, thread);
+        threadMap.put(jni_env, thread_info.name);
     }
     pthread_sigmask(SIG_UNBLOCK, &prof_signal_mask, NULL);
 }

--- a/src/main/cpp/circular_queue.h
+++ b/src/main/cpp/circular_queue.h
@@ -6,15 +6,9 @@
 #ifndef CIRCULAR_QUEUE_H
 #define CIRCULAR_QUEUE_H
 
+#include "thread_map.h"
 #include "stacktraces.h"
 #include <string.h>
-
-#if __GNUC__ == 4 && __GNUC_MINOR__ < 6 && !defined(__APPLE__) && !defined(__FreeBSD__) 
-  #include <cstdatomic>
-#else
-  #include <atomic>
-#endif
-
 #include <cstddef>
 
 const size_t Size = 1024;
@@ -27,7 +21,7 @@ const size_t Capacity = Size + 1;
 
 class QueueListener {
 public:
-    virtual void record(const JVMPI_CallTrace &item) = 0;
+    virtual void record(const JVMPI_CallTrace &item, ThreadBucket *info = nullptr) = 0;
 
     virtual ~QueueListener() {
     }
@@ -39,6 +33,7 @@ const int UNCOMMITTED = 0;
 struct TraceHolder {
     std::atomic<int> is_committed;
     JVMPI_CallTrace trace;
+    ThreadBucket *info;
 };
 
 class CircularQueue {
@@ -55,7 +50,7 @@ public:
             delete[] frame_buffer_[i];
     }
 
-    bool push(const JVMPI_CallTrace &item);
+    bool push(const JVMPI_CallTrace &item, ThreadBucket *info = nullptr);
 
     bool pop();
 

--- a/src/main/cpp/log_writer.cpp
+++ b/src/main/cpp/log_writer.cpp
@@ -22,29 +22,6 @@ void LogWriter::writeValue(const T &value) {
     }
 }
 
-static int64_t getThreadId(JNIEnv *env_id, jvmtiEnv *tiEnv, ThreadMap &tMap) {
-    ThreadBucket *tInfo = tMap.get(env_id);
-    if (tInfo && tInfo->tid > 0) {
-        return (int64_t)tInfo->tid;
-    }
-    return (int64_t)env_id;
-}
-
-static void getThreadName(JNIEnv *env_id, jvmtiEnv *tiEnv, ThreadMap &tMap, char *buff, int buffsz) {
-    jvmtiThreadInfo thread_info;
-    char *src = (char*)"Unknown";
-    ThreadBucket *tInfo = tMap.get(env_id);
-    if (tInfo && tInfo->tid > 0) {
-        int error = tiEnv->GetThreadInfo(tInfo->thread, &thread_info);
-        if (error == JNI_OK) {
-            src = thread_info.name;
-        }
-    }
-    int symbols = std::min((int)strlen(src), buffsz - 1);
-    strncpy(buff, src, symbols);
-    buff[symbols] = '\0';
-}
-
 static jint bci2line(jint bci, jvmtiLineNumberEntry *table, jint entry_count) {
 	jint line_number = -101;
 	if ( entry_count == 0 ) {
@@ -101,12 +78,17 @@ jint LogWriter::getLineNo(jint bci, jmethodID methodId) {
     return lineno;
 }
 
-void LogWriter::record(const JVMPI_CallTrace &trace) {
-    constexpr const int size = 128;
-    char namebuff[size];
+void LogWriter::record(const JVMPI_CallTrace &trace, ThreadBucket *info) {
+    map::HashType threadId = (map::HashType) trace.env_id;
+    // char *src = (char*)"";
 
-    int64_t threadId = getThreadId(trace.env_id, jvmti_, tMap_);
-    getThreadName(trace.env_id, jvmti_, tMap_, namebuff, size);
+    if (info) {
+        threadId = (map::HashType) info->tid;
+        // src = info->name;
+    }
+
+    // std::cout << "#### thread: " << trace.env_id << ", tid: " << threadId << ", src: " << src << std::endl;
+
     recordTraceStart(trace.num_frames, threadId);
 
     for (int i = 0; i < trace.num_frames; i++) {
@@ -124,14 +106,9 @@ void LogWriter::record(const JVMPI_CallTrace &trace) {
         }
         inspectMethod(methodId, frame);
     }
-}
 
-void LogWriter::startup() {
-    tMap_.attachReader();
-}
-
-void LogWriter::terminate() {
-    tMap_.detachReader();
+    if (info != nullptr)
+        info->release();
 }
 
 void LogWriter::inspectMethod(const method_id methodId,
@@ -144,7 +121,7 @@ void LogWriter::inspectMethod(const method_id methodId,
     frameLookup_(frame, jvmti_, *this);
 }
 
-void LogWriter::recordTraceStart(const jint numFrames, const int64_t threadId) {
+void LogWriter::recordTraceStart(const jint numFrames, const map::HashType threadId) {
     output_.put(TRACE_START);
     writeValue(numFrames);
     writeValue(threadId);
@@ -173,7 +150,7 @@ void LogWriter::writeWithSize(const char *value) {
     output_.write(value, size);
 }
 
-void LogWriter::recordNewMethod(const int64_t methodId, const char *fileName,
+void LogWriter::recordNewMethod(const map::HashType methodId, const char *fileName,
         const char *className, const char *methodName) {
     output_.put(NEW_METHOD);
     writeValue(methodId);

--- a/src/main/cpp/log_writer.cpp
+++ b/src/main/cpp/log_writer.cpp
@@ -126,8 +126,12 @@ void LogWriter::record(const JVMPI_CallTrace &trace) {
     }
 }
 
+void LogWriter::startup() {
+    tMap_.attachReader();
+}
+
 void LogWriter::terminate() {
-    tMap_.detach();
+    tMap_.detachReader();
 }
 
 void LogWriter::inspectMethod(const method_id methodId,

--- a/src/main/cpp/log_writer.h
+++ b/src/main/cpp/log_writer.h
@@ -51,6 +51,8 @@ public:
 
     virtual void record(const JVMPI_CallTrace &trace);
 
+    virtual void startup();    
+
     virtual void terminate();
 
     void recordTraceStart(const jint num_frames, const int64_t threadId);

--- a/src/main/cpp/log_writer.h
+++ b/src/main/cpp/log_writer.h
@@ -45,8 +45,8 @@ class LogWriter : public QueueListener, public MethodListener {
 
 public:
     explicit LogWriter(ostream &output, GetFrameInformation frameLookup,
-            jvmtiEnv *jvmti, ThreadMap &tMap)
-            : output_(output), frameLookup_(frameLookup), jvmti_(jvmti), tMap_(tMap) {
+            jvmtiEnv *jvmti)
+            : output_(output), frameLookup_(frameLookup), jvmti_(jvmti) {
     }
 
     virtual void record(const JVMPI_CallTrace &trace, ThreadBucket *info = nullptr);
@@ -68,8 +68,6 @@ private:
     GetFrameInformation frameLookup_;
 
     jvmtiEnv *jvmti_;
-
-    ThreadMap &tMap_;
 
     unordered_set<method_id> knownMethods;
 

--- a/src/main/cpp/log_writer.h
+++ b/src/main/cpp/log_writer.h
@@ -49,13 +49,9 @@ public:
             : output_(output), frameLookup_(frameLookup), jvmti_(jvmti), tMap_(tMap) {
     }
 
-    virtual void record(const JVMPI_CallTrace &trace);
+    virtual void record(const JVMPI_CallTrace &trace, ThreadBucket *info = nullptr);
 
-    virtual void startup();    
-
-    virtual void terminate();
-
-    void recordTraceStart(const jint num_frames, const int64_t threadId);
+    void recordTraceStart(const jint num_frames, const map::HashType threadId);
 
     // method are unique pointers, use a long to standardise
     // between 32 and 64 bits

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -28,7 +28,6 @@ TRACE_DEFINE_END(Processor, kTraceProcessorTotal);
 
 void Processor::run() {
     int popped = 0;
-    logWriter_.startup();
 
     while (true) {
         while (buffer_.pop()) {
@@ -50,7 +49,6 @@ void Processor::run() {
     }
 
     handler_.stopSigprof();
-    logWriter_.terminate(); // make sure processing thread is detached from thread map
     workerDone.clear(std::memory_order_relaxed);
     // no shared data access after this point, can be safely deleted
 }

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -28,6 +28,7 @@ TRACE_DEFINE_END(Processor, kTraceProcessorTotal);
 
 void Processor::run() {
     int popped = 0;
+    logWriter_.startup();
 
     while (true) {
         while (buffer_.pop()) {

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -256,7 +256,7 @@ void Profiler::configure() {
             // The JVM will still continue to run though; could call abort() to terminate the JVM abnormally.
             logError("ERROR: Failed to open file %s for writing\n", fileName);
         }
-        writer = new LogWriter(*logFile, &Profiler::lookupFrameInformation, jvmti_, tMap_);
+        writer = new LogWriter(*logFile, &Profiler::lookupFrameInformation, jvmti_);
     }
 
     needsUpdate = needsUpdate || configuration_->maxFramesToCapture != liveConfiguration->maxFramesToCapture;

--- a/src/main/cpp/thread_map.h
+++ b/src/main/cpp/thread_map.h
@@ -3,30 +3,38 @@
 
 #include <jvmti.h>
 #include <jni.h>
+#include <string.h>
 #include "concurrent_map.h"
 
 
 int gettid();
 
+
 template <typename PType>
 struct PointerHasher {
-	/* pointer hash bijection (collision-free) */
+	/* Numerical Recipes, 3rd Edition */
 	static int64_t hash(void *p) {
-		// remove LSB zeros in pointers
-		return ((int64_t)p) / sizeof(PType);
+		int64_t v = (int64_t)p / sizeof(PType);
+		v = v * 3935559000370003845 + 2691343689449507681;
+
+  		v ^= v >> 21;
+  		v ^= v << 37;
+  		v ^= v >>  4;
+
+  		v *= 4768777513237032717;
+
+  		v ^= v << 20;
+  		v ^= v >> 41;
+  		v ^= v <<  5;
+
+  		return v;
 	}
 };
 
 const int kInitialMapSize = 256;
-const int KSafepointTrigger = 32; // each 32nd read results in safepoint
 
 class GCHelper {
 public:
-	static void safepointOnDemand(map::GC::EpochType &localEpoch, unsigned int &count) {
-		if (!(count++ & (KSafepointTrigger - 1))) // count = 0 (mod KSafepointTrigger)
-			map::DefaultGC.safepoint(localEpoch);
-	}
-
 	static map::GC::EpochType attach() {
 		return map::DefaultGC.attachThread();
 	}
@@ -39,25 +47,40 @@ public:
 	static void safepoint(map::GC::EpochType &localEpoch) {
 		map::DefaultGC.safepoint(localEpoch);
 	}
+
+	static void signalSafepoint(map::GC::EpochType &localEpoch) {
+		map::DefaultGC.ss_safepoint(localEpoch);
+	}
 };
 
 struct ThreadBucket {
 	const int tid;
-	const jthread thread;
-	map::GC::EpochType localEpoch;
+	char *name;
 	std::atomic_int refs;
+	map::GC::EpochType localEpoch;
 
-	ThreadBucket(int id, jthread thr) : tid(id), thread(thr), localEpoch(GCHelper::attach()), refs(1) {
+	ThreadBucket(int id, const char *n) : tid(id), refs(1), localEpoch(GCHelper::attach()) {
+		int len = strlen(n) + 1;
+		name = new char[len];
+		std::copy(n, n + len, name);
+	}
+
+	void release() {
+		int prev = refs.fetch_sub(1, std::memory_order_acquire);
+		if (prev == 1)
+			delete this;
+	}
+
+	~ThreadBucket() {
+		delete[] name;
 	}
 };
 
-// MWSR
+
 template <typename MapProvider>
 class ThreadMapBase {
 private:
 	MapProvider map;
-	map::GC::EpochType readerEpoch;
-	unsigned int readerCounter;
 
 	static ThreadBucket *acq_bucket(ThreadBucket *tb) {
 		if (tb != nullptr) {
@@ -70,62 +93,39 @@ private:
 		return nullptr;
 	}
 
-	static void rel_bucket(ThreadBucket *tb, JNIEnv *jni_env) {
-		if (tb != nullptr) {
-			int prev = tb->refs.fetch_sub(1, std::memory_order_acquire);
-			if (prev == 1) {
-				jni_env->DeleteGlobalRef(tb->thread);
-				delete tb;
-			}
-		}
-	}
-
 public:
 
-	ThreadMapBase(int capacity = kInitialMapSize) : map(capacity) {
-		readerEpoch = map::GC::kEpochInitial;
-		readerCounter = 0;
+	ThreadMapBase(int capacity = kInitialMapSize) : map(capacity) {}
+
+	void put(JNIEnv *jni_env, const char *name) {
+		put(jni_env, name, gettid());
 	}
 
-	void put(JNIEnv *jni_env, jthread thread) {
-		put(jni_env, thread, gettid());
-	}
-
-	void put(JNIEnv *jni_env, jthread thread, int tid, bool globalRef = true) {
+	void put(JNIEnv *jni_env, const char *name, int tid) {
 		// constructor == call to acquire
-		ThreadBucket *info = new ThreadBucket(tid, globalRef ? thread : jni_env->NewGlobalRef(thread));
+		ThreadBucket *info = new ThreadBucket(tid, name);
 		ThreadBucket *old = (ThreadBucket*)map.put((map::KeyType)jni_env, (map::ValueType)info);
-		rel_bucket(old, jni_env);
+		if (old != nullptr)
+			old->release();
 		GCHelper::safepoint(info->localEpoch); // each thread inserts once
 	}
 
 	ThreadBucket *get(JNIEnv *jni_env) {
-		GCHelper::safepointOnDemand(readerEpoch, readerCounter);
-		return acq_bucket((ThreadBucket*)map.get((map::KeyType)jni_env));
+		ThreadBucket *info = acq_bucket((ThreadBucket*)map.get((map::KeyType)jni_env));
+		if (info != nullptr)
+			GCHelper::signalSafepoint(info->localEpoch);
+		return info;
 	}
 
 	void remove(JNIEnv *jni_env) {
 		ThreadBucket *info = (ThreadBucket*)map.remove((map::KeyType)jni_env);
-		if (info) {
+		if (info != nullptr) {
 			GCHelper::detach(info->localEpoch);
-			rel_bucket(info, jni_env);
-		}
-	}
-
-	void attachReader() {
-		if (readerEpoch == map::GC::kEpochInitial) {
-			readerEpoch = GCHelper::attach();
-			readerCounter = 0;
-		}
-	}
-
-	void detachReader() {
-		if (readerEpoch != map::GC::kEpochInitial) {
-			GCHelper::detach(readerEpoch);
+			info->release();
 		}
 	}
 };
 
-typedef ThreadMapBase<map::ConcurrentMapProvider<PointerHasher<JNIEnv>, false> > ThreadMap;
+typedef ThreadMapBase<map::ConcurrentMapProvider<PointerHasher<JNIEnv>, true> > ThreadMap;
 
 #endif

--- a/src/main/cpp/thread_map.h
+++ b/src/main/cpp/thread_map.h
@@ -8,11 +8,6 @@
 
 int gettid();
 
-struct ThreadBucket {
-	int tid;
-	jthread thread;
-};
-
 template <typename PType>
 struct PointerHasher {
 	/* pointer hash bijection (collision-free) */
@@ -25,76 +20,109 @@ struct PointerHasher {
 const int kInitialMapSize = 256;
 const int KSafepointTrigger = 32; // each 32nd read results in safepoint
 
-thread_local static map::GC::EpochType localEpoch = map::GC::kEpochInitial;
-thread_local static int mapUsageCounter = 0;
-
 class GCHelper {
 public:
-	static void safepointOnDemand() {
-		if (!(mapUsageCounter++ & (KSafepointTrigger - 1))) // mapUsageCounter = 0 (mod KSafepointTrigger)
+	static void safepointOnDemand(map::GC::EpochType &localEpoch, unsigned int &count) {
+		if (!(count++ & (KSafepointTrigger - 1))) // count = 0 (mod KSafepointTrigger)
 			map::DefaultGC.safepoint(localEpoch);
 	}
 
-	static void attach() {
-		if (localEpoch == map::GC::kEpochInitial)
-			localEpoch = map::DefaultGC.attachThread();
+	static map::GC::EpochType attach() {
+		return map::DefaultGC.attachThread();
 	}
 
-	static void detach() {
+	static void detach(map::GC::EpochType &localEpoch) {
 		if (localEpoch != map::GC::kEpochInitial)
 			map::DefaultGC.detachThread(localEpoch);
 	}
 
-	static void safepoint() {
-		if (localEpoch == map::GC::kEpochInitial) attach();
+	static void safepoint(map::GC::EpochType &localEpoch) {
 		map::DefaultGC.safepoint(localEpoch);
 	}
 };
 
+struct ThreadBucket {
+	const int tid;
+	const jthread thread;
+	map::GC::EpochType localEpoch;
+	std::atomic_int refs;
+
+	ThreadBucket(int id, jthread thr) : tid(id), thread(thr), localEpoch(GCHelper::attach()), refs(1) {
+	}
+};
+
+// MWSR
 template <typename MapProvider>
 class ThreadMapBase {
 private:
 	MapProvider map;
+	map::GC::EpochType readerEpoch;
+	unsigned int readerCounter;
+
+	static ThreadBucket *acq_bucket(ThreadBucket *tb) {
+		if (tb != nullptr) {
+			int prev = tb->refs.fetch_add(1, std::memory_order_relaxed);
+			if (prev > 0) {
+				return tb;
+			}
+			tb->refs.fetch_sub(1, std::memory_order_relaxed);
+		}
+		return nullptr;
+	}
+
+	static void rel_bucket(ThreadBucket *tb, JNIEnv *jni_env) {
+		if (tb != nullptr) {
+			int prev = tb->refs.fetch_sub(1, std::memory_order_acquire);
+			if (prev == 1) {
+				jni_env->DeleteGlobalRef(tb->thread);
+				delete tb;
+			}
+		}
+	}
 
 public:
 
-	ThreadMapBase(int capacity = kInitialMapSize) : map(capacity) {}
+	ThreadMapBase(int capacity = kInitialMapSize) : map(capacity) {
+		readerEpoch = map::GC::kEpochInitial;
+		readerCounter = 0;
+	}
 
 	void put(JNIEnv *jni_env, jthread thread) {
 		put(jni_env, thread, gettid());
 	}
 
 	void put(JNIEnv *jni_env, jthread thread, int tid, bool globalRef = true) {
-		GCHelper::attach();
-		ThreadBucket *info = new ThreadBucket;
-		info->tid = tid;
-		info->thread = globalRef ? thread : jni_env->NewGlobalRef(thread);
-		map.put((map::KeyType)jni_env, (map::ValueType)info);
-		GCHelper::safepoint(); // each thread inserts once
+		// constructor == call to acquire
+		ThreadBucket *info = new ThreadBucket(tid, globalRef ? thread : jni_env->NewGlobalRef(thread));
+		ThreadBucket *old = (ThreadBucket*)map.put((map::KeyType)jni_env, (map::ValueType)info);
+		rel_bucket(old, jni_env);
+		GCHelper::safepoint(info->localEpoch); // each thread inserts once
 	}
 
 	ThreadBucket *get(JNIEnv *jni_env) {
-		GCHelper::attach();
-		GCHelper::safepointOnDemand();
-		return reinterpret_cast<ThreadBucket*>(map.get((map::KeyType)jni_env));
+		GCHelper::safepointOnDemand(readerEpoch, readerCounter);
+		return acq_bucket((ThreadBucket*)map.get((map::KeyType)jni_env));
 	}
 
 	void remove(JNIEnv *jni_env) {
-		GCHelper::attach();
 		ThreadBucket *info = (ThreadBucket*)map.remove((map::KeyType)jni_env);
 		if (info) {
-			jni_env->DeleteGlobalRef(info->thread);
-			delete info;
+			GCHelper::detach(info->localEpoch);
+			rel_bucket(info, jni_env);
 		}
-		GCHelper::safepoint(); // each thread deletes once
 	}
 
-	void attach() {
-		GCHelper::attach();
+	void attachReader() {
+		if (readerEpoch == map::GC::kEpochInitial) {
+			readerEpoch = GCHelper::attach();
+			readerCounter = 0;
+		}
 	}
 
-	void detach() {
-		GCHelper::detach();
+	void detachReader() {
+		if (readerEpoch != map::GC::kEpochInitial) {
+			GCHelper::detach(readerEpoch);
+		}
 	}
 };
 

--- a/src/test/cpp/fixtures.h
+++ b/src/test/cpp/fixtures.h
@@ -8,7 +8,7 @@ class ItemHolder : public QueueListener {
 public:
   explicit ItemHolder() {}
 
-  virtual void record(const JVMPI_CallTrace &trace) {
+  virtual void record(const JVMPI_CallTrace &trace, ThreadBucket *info) {
     CHECK_EQUAL(2, trace.num_frames);
     CHECK_EQUAL((JNIEnv *)envId, trace.env_id);
 

--- a/src/test/cpp/test_log_writer.cpp
+++ b/src/test/cpp/test_log_writer.cpp
@@ -25,8 +25,7 @@ bool stubFrameInformation(const JVMPI_CallFrame &frame, jvmtiEnv *jvmti,
   char buffer[100] = {};                                                       \
   ostreambuf<char> outputBuffer(buffer, sizeof(buffer));                       \
   ostream output(&outputBuffer);                                               \
-  ThreadMap emptyMapStub;                                                      \
-  LogWriter logWriter(output, &stubFrameInformation, NULL, emptyMapStub);      \
+  LogWriter logWriter(output, &stubFrameInformation, NULL);                    \
   CircularQueue *queue = new CircularQueue(logWriter, DEFAULT_MAX_FRAMES_TO_CAPTURE);
 
 #define done() delete queue;
@@ -157,9 +156,8 @@ bool dumpStubFrameInformation(const JVMPI_CallFrame &frame, jvmtiEnv *jvmti,
 TEST(DumpTestFile) {
   givenStackTrace();
 
-  ThreadMap tMap;
   ofstream output("dump.hpl", ofstream::out | ofstream::binary);
-  LogWriter logWriter(output, &dumpStubFrameInformation, NULL, tMap);
+  LogWriter logWriter(output, &dumpStubFrameInformation, NULL);
 
   logWriter.record(trace);
   logWriter.record(trace);

--- a/src/test/cpp/test_log_writer.cpp
+++ b/src/test/cpp/test_log_writer.cpp
@@ -29,7 +29,7 @@ bool stubFrameInformation(const JVMPI_CallFrame &frame, jvmtiEnv *jvmti,
   LogWriter logWriter(output, &stubFrameInformation, NULL, emptyMapStub);      \
   CircularQueue *queue = new CircularQueue(logWriter, DEFAULT_MAX_FRAMES_TO_CAPTURE);
 
-#define done() logWriter.terminate(); delete queue;
+#define done() delete queue;
 
 TEST(RecordsStartOfStackTrace) {
   givenLogWriter();
@@ -163,5 +163,4 @@ TEST(DumpTestFile) {
 
   logWriter.record(trace);
   logWriter.record(trace);
-  logWriter.terminate(); // detach a thread from map
 }

--- a/src/test/cpp/test_maps.cpp
+++ b/src/test/cpp/test_maps.cpp
@@ -33,32 +33,32 @@ void deallocateTestBuffer(void **b, size_t size) {
 #define IDX(rev, i, sz) ((rev) ? (sz - 1 - i) : (i))
 
 void mapWriter(AbstractMapProvider &map, void **keys, void **values, std::atomic<void*> *result, size_t size, bool reverse=false) {
-	GCHelper::attach();
+	map::GC::EpochType id = GCHelper::attach();
 	for (int i = 0; i < size; i++) {
 		map.put(keys[IDX(reverse, i, size)], values[IDX(reverse, i, size)]);
 	}
-	GCHelper::safepoint();
-	GCHelper::detach();
+	GCHelper::safepoint(id);
+	GCHelper::detach(id);
 }
 
 void mapReader(AbstractMapProvider &map, void **keys, void **values, std::atomic<void*> *result, size_t size, bool reverse=false) {
-	GCHelper::attach();
+	map::GC::EpochType id = GCHelper::attach();
 	for (int i = 0; i < size; i++) {
 		void *res = map.get(keys[IDX(reverse, i, size)]);
 		result[IDX(reverse, i, size)].store(res, std::memory_order_relaxed);
 	}
-	GCHelper::safepoint();
-	GCHelper::detach();
+	GCHelper::safepoint(id);
+	GCHelper::detach(id);
 }
 
 void mapRemover(AbstractMapProvider &map, void **keys, void **values, std::atomic<void*> *result, size_t size, bool reverse=false) {
-	GCHelper::attach();
+	map::GC::EpochType id = GCHelper::attach();
 	for (int i = 0; i < size; i++) {
 		void *res = map.remove(keys[IDX(reverse, i, size)]);
 		result[IDX(reverse, i, size)].store(res, std::memory_order_relaxed);
 	}
-	GCHelper::safepoint();
-	GCHelper::detach();
+	GCHelper::safepoint(id);
+	GCHelper::detach(id);
 }
 
 template <bool overlap=false, bool altDirection=false>
@@ -182,7 +182,7 @@ TEST(LockFreeHashMapBasicConcurrentChecks) {
 
 	void *res;
 
-	GCHelper::attach();
+	map::GC::EpochType id = GCHelper::attach();
 
 	mapReader(map, keys, values, results, 1);
 	CHECK_ARRAY_EQUAL(nullarr, results, 1);
@@ -197,7 +197,7 @@ TEST(LockFreeHashMapBasicConcurrentChecks) {
 	CHECK_EQUAL((void*)NULL, res);
 	remover.join();
 
-	GCHelper::detach();
+	GCHelper::detach(id);
 
 	CHECK_EQUAL(0, map.unsafeUsed());
 #ifdef DEBUG_MAP_GC
@@ -319,7 +319,7 @@ TEST(LockFreeHashMapConcurrentMixedLoad) {
 			bool *conditions = new bool[bSize]();
 			int conditionsMet = 0;
 
-			GCHelper::attach();
+			map::GC::EpochType id = GCHelper::attach();
 			
 			while (conditionsMet < bSize) {
 				for (int i = 0; i < jobSize; ++i) {
@@ -334,11 +334,11 @@ TEST(LockFreeHashMapConcurrentMixedLoad) {
 						if (conditions[i + jobSize]) conditionsMet++;
 					}
 				}
-				GCHelper::safepoint();
+				GCHelper::safepoint(id);
 			}
 			delete[] conditions;
 
-			GCHelper::detach();
+			GCHelper::detach(id);
 
 			writer.join();
 			remover.join();

--- a/src/test/cpp/test_maps.cpp
+++ b/src/test/cpp/test_maps.cpp
@@ -9,7 +9,13 @@
 
 using namespace map;
 
-typedef ConcurrentMapProvider<PointerHasher<int>, false> TestLockFreeMap;
+struct TestHasher {
+	static int64_t hash(void *p) {
+  		return (int64_t)p / sizeof(int);
+	}
+};
+
+typedef ConcurrentMapProvider<TestHasher, false> TestLockFreeMap;
 typedef void (*MapFunction)(AbstractMapProvider &, void **, void **, std::atomic<void*> *, size_t, bool);
 
 void **allocateTestBuffer(size_t size) {


### PR DESCRIPTION
I've refactored ThreadMap a little to get rid of `thread_local` variables. This is required to support version of clang shipped with XCode to fix #1 issue reported by @eljobe. 

Also reference counting guards were added to `ThreadMap` to prevent heap corruption when `get` and `remove` for the same `JNIenv` happen simultaneously.  